### PR TITLE
Change all default ports for dev environment

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -4,14 +4,15 @@ import { platform } from 'os'
 import cypressPlugins from './cypress/plugins'
 
 const IS_CI = Boolean(process.env.CI)
-const DEFAULT_PORT = IS_CI || platform() === 'darwin' ? 8880 : 3000
+const IS_DARWIN = platform() === 'darwin'
+const DEFAULT_PORT = IS_CI ? 8880 : 4000
 
 export default defineConfig({
   // We do that to avoid e2e logs pollution with useless`GET /security-state-staging/intermediates/` lines
   // Despite the name, this aso applies to Firefox
   chromeWebSecurity: false,
   e2e: {
-    baseUrl: IS_CI ? `http://localhost:${DEFAULT_PORT}` : `http://0.0.0.0:3000`,
+    baseUrl: `http://${IS_DARWIN ? '0.0.0.0' : 'localhost'}:${DEFAULT_PORT}`,
     excludeSpecPattern: ['**/__snapshots__/*', '**/__image_snapshots__/*'],
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "build-storybook -s public",
     "cypress:open": "cypress open --browser firefox --e2e",
     "cypress:run": "cypress run --browser firefox --e2e",
-    "dev": "BROWSER=none DISABLE_ESLINT_PLUGIN=true react-scripts start",
+    "dev": "PORT=4000 BROWSER=none DISABLE_ESLINT_PLUGIN=true react-scripts start",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
     "storybook": "start-storybook -p 6006 -s public",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -148,7 +148,7 @@
       "bash -c 'npm run test:type:partial'"
     ]
   },
-  "proxy": "http://localhost:8880",
+  "proxy": "http://localhost:9880",
   "overrides": {
     "react-refresh": "0.11.0"
   }

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -5,7 +5,7 @@ PROJECT_NAME=monitorenv
 
 # Database host from geoserver container
 GEOSERVER_DB_HOST=db
-GEOSERVER_PORT=8081
+GEOSERVER_PORT=9081
 GEOSERVER_ADMIN_USER=geoserveradmin
 GEOSERVER_ADMIN_PASSWORD=changeme
 # Host to access geoserver from within the server
@@ -14,7 +14,7 @@ GEOSERVER_HOST=localhost
 ################################################################################
 # PostgreSQL
 
-POSTGRES_PORT=5432
+POSTGRES_PORT=6432
 POSTGRES_USER=postgres
 POSTGRES_DB=monitorenvdb
 POSTGRES_HOST=localhost
@@ -25,14 +25,14 @@ POSTGRES_PASSWORD=postgres
 ################################################################################
 # Backend
 
-BACKEND_HTTP_PORT=8880
+BACKEND_HTTP_PORT=9880
 
 ################################################################################
 # Frontend
 
 # These variables are reinjected at runtime :
 # Public Geoserver URL (readonly)
-REACT_APP_GEOSERVER_REMOTE_URL=//localhost:8081
+REACT_APP_GEOSERVER_REMOTE_URL=//localhost:9081
 # Production:
 # REACT_APP_GEOSERVER_REMOTE_URL=https://monitorenv.din.developpement-durable.gouv.fr
 

--- a/infra/configurations/backend/application-dev.properties
+++ b/infra/configurations/backend/application-dev.properties
@@ -1,17 +1,17 @@
 ######################
 # Application settings
-monitorenv.server.root=http://localhost:8880
-monitorenv.server.port=8880
+monitorenv.server.root=http://localhost:9880
+monitorenv.server.port=9880
 monitorenv.flyway.locations=classpath:/db/migration,classpath:/db/testdata
 spring.flyway.group=true
 # spring.flyway.out-of-order=true
 
-monitorenv.ajp.port=8000
-host.ip=localhost:8880
+monitorenv.ajp.port=9000
+host.ip=localhost:9880
 
 ###################
 # Database settings
 spring.jpa.show-sql=true
 
 # Database used by the application (problem with upper case)
-env.db.url=jdbc:postgresql://localhost:5432/monitorenvdb?user=postgres&password=postgres
+env.db.url=jdbc:postgresql://localhost:6432/monitorenvdb?user=postgres&password=postgres


### PR DESCRIPTION
In order to easily launch both Fish & Env locally out-of-the-box and without "hacking" a few ports, I suggest in this PR to increase all env ports (when in dev)  to +1XXX (i.e.: 8XXX becomes 9XXX).