### PR TITLE
[carte] : fix bug lorsqu'on zoom sur une étendue non valide

### DIFF
--- a/frontend/src/features/map/MapExtentController.ts
+++ b/frontend/src/features/map/MapExtentController.ts
@@ -11,7 +11,7 @@ export function MapExtentController({ map }: MapChildrenProps) {
   const { fitToExtent, zoomToCenter } = useAppSelector(state => state.map)
 
   useEffect(() => {
-    if (fitToExtent) {
+    if (fitToExtent && fitToExtent[0] !== Infinity) {
       const options = {
         duration: DEFAULT_MAP_ANIMATION_DURATION,
         maxZoom: MAX_ZOOM_LEVEL,


### PR DESCRIPTION
Dans le cas où la géométrie n'est pas valide. Pourrait éventuellement arriver car pas de validation des géométries coté back.