### PR TITLE
[Semaphores] Améliorations design

### DIFF
--- a/frontend/public/semaphore.svg
+++ b/frontend/public/semaphore.svg
@@ -1,5 +1,5 @@
 <svg id="Semaphore" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
   <path id="Tracé_1515" data-name="Tracé 1515" d="M0,0H20V20H0Z" fill="none"/>
   <path id="Tracé_1516" data-name="Tracé 1516" d="M0,0H20V20H0Z" fill="none"/>
-  <path id="Tracé_1602" data-name="Tracé 1602" d="M18,1H2V5H5L4,19H7V15h3v4h6L15,5h3ZM5,3.5H3v-2H5Zm3,0H6v-2H8Zm3,0H9v-2h2Zm3,0H12v-2h2Zm3,0H15v-2h2Z" fill="#707785"/>
+  <path id="Tracé_1602" data-name="Tracé 1602" d="M18,1H2V5H5L4,19H7V15h3v4h6L15,5h3ZM5,3.5H3v-2H5Zm3,0H6v-2H8Zm3,0H9v-2h2Zm3,0H12v-2h2Zm3,0H15v-2h2Z" fill="#3B4559"/>
 </svg>

--- a/frontend/src/features/Semaphores/SearchSemaphoreButton/SearchSemaphores.tsx
+++ b/frontend/src/features/Semaphores/SearchSemaphoreButton/SearchSemaphores.tsx
@@ -73,7 +73,7 @@ export function SearchSemaphores() {
         />
       </MenuWithCloseButton.Header>
 
-      <Search
+      <StyledSearch
         customSearch={customSearchRef.current}
         isLabelHidden
         isLight
@@ -100,6 +100,12 @@ export function SearchSemaphores() {
     </MenuWithCloseButton.Container>
   )
 }
+
+const StyledSearch = styled(Search)`
+  .rs-picker-menu {
+    width: 100%;
+  }
+`
 
 const StyledRegisteredSemaphoreList = styled.div`
   display: flex;

--- a/frontend/src/features/Semaphores/SearchSemaphoreButton/SearchSemaphores.tsx
+++ b/frontend/src/features/Semaphores/SearchSemaphoreButton/SearchSemaphores.tsx
@@ -42,16 +42,16 @@ export function SearchSemaphores() {
     if (selectedSemaphore) {
       dispatch(addSemaphore(selectedSemaphore))
       dispatch(setSelectedSemaphore(selectedSemaphore.id))
-      zoomOnSempahore(selectedSemaphore.geom)
+      zoomOnSemaphore(selectedSemaphore.geom)
     }
   }
 
   const selectRegiteredSemaphore = selectedRegisteredSemaphore => {
     dispatch(setSelectedSemaphore(selectedRegisteredSemaphore.id))
-    zoomOnSempahore(selectedRegisteredSemaphore.geom)
+    zoomOnSemaphore(selectedRegisteredSemaphore.geom)
   }
 
-  const zoomOnSempahore = geom => {
+  const zoomOnSemaphore = geom => {
     const feature = new GeoJSON({
       featureProjection: OPENLAYERS_PROJECTION
     }).readFeature(geom)

--- a/frontend/src/features/map/layers/Semaphores/semaphores.style.ts
+++ b/frontend/src/features/map/layers/Semaphores/semaphores.style.ts
@@ -23,7 +23,6 @@ const lineStyle = new Style({
 
 const semaphoreStyle = new Style({
   image: new Icon({
-    color: COLORS.charcoal,
     src: 'semaphore.svg'
   })
 })

--- a/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
+++ b/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import { COLORS } from '../../../constants/constants'
 import { setOverlayCoordinates } from '../../../domain/shared_slices/Global'
 import { useAppDispatch } from '../../../hooks/useAppDispatch'
+import { useAppSelector } from '../../../hooks/useAppSelector'
 import { useMoveOverlayWhenDragging } from '../../../hooks/useMoveOverlayWhenDragging'
 import { getOverlayPositionForCentroid, getTopLeftMargin } from './position'
 
@@ -19,7 +20,7 @@ const defaultMargins = {
   xRight: -155,
   yBottom: 50,
   yMiddle: 100,
-  yTop: -200
+  yTop: -180
 }
 
 export function OverlayPositionOnCentroid({
@@ -36,6 +37,7 @@ export function OverlayPositionOnCentroid({
   const isThrottled = useRef(false)
   const [showed, setShowed] = useState(false)
   const currentCoordinates = useRef([])
+  const { overlayCoordinates } = useAppSelector(state => state.global)
 
   const [overlayTopLeftMargin, setOverlayTopLeftMargin] = useState([margins.yBottom, margins.xMiddle])
   const currentOffset = useRef(INITIAL_OFFSET_VALUE)
@@ -67,6 +69,15 @@ export function OverlayPositionOnCentroid({
       currentCoordinates.current = undefined
     }
   }, [feature])
+
+  useEffect(() => {
+    const view = map.getView()
+    view.on('change:resolution', () => {
+      if (overlayCoordinates) {
+        dispatch(setOverlayCoordinates(undefined))
+      }
+    })
+  }, [dispatch, map, overlayCoordinates])
 
   useEffect(() => {
     if (map) {

--- a/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
+++ b/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
@@ -159,4 +159,5 @@ const OverlayComponent = styled.div`
   text-align: left;
   background-color: ${COLORS.white};
   border-radius: 2px;
+  cursor: grabbing;
 `

--- a/frontend/src/features/map/overlays/position.js
+++ b/frontend/src/features/map/overlays/position.js
@@ -159,7 +159,7 @@ export function getOverlayPositionForCentroid(boxSize, x, y, extent) {
     return OverlayPosition.TOP
   }
 
-  return OverlayPosition.BOTTOM
+  return OverlayPosition.TOP
 }
 
 /**

--- a/frontend/src/features/map/overlays/semaphores/SemaphoreCard.tsx
+++ b/frontend/src/features/map/overlays/semaphores/SemaphoreCard.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import { Tooltip, Whisper } from 'rsuite'
 import styled from 'styled-components'
 
+import { COLORS } from '../../../../constants/constants'
 import { setOverlayCoordinates } from '../../../../domain/shared_slices/Global'
 import { resetSelectedSemaphore } from '../../../../domain/shared_slices/SemaphoresSlice'
 import { useAppSelector } from '../../../../hooks/useAppSelector'
@@ -75,7 +76,7 @@ export function SemaphoreCard({ feature, selected = false }: { feature: any; sel
         <CloseButton
           $isVisible={selected}
           accent={Accent.TERTIARY}
-          data-cy="sempahore-overlay-close"
+          data-cy="semaphore-overlay-close"
           Icon={Icon.Close}
           iconSize={14}
           onClick={handleCloseOverlay}
@@ -84,26 +85,46 @@ export function SemaphoreCard({ feature, selected = false }: { feature: any; sel
 
       <StyledContactContainer>
         {phoneNumber && (
-          <Whisper
-            controlId="phone-tooltip"
-            onClick={onCopyPhone}
-            placement="right"
-            speaker={hoverTooltip(tooltipPhoneState.text, tooltipPhoneState.className)}
-            trigger={tooltipPhoneState.trigger as OverlayTriggerType}
-          >
-            <StyledContact>Contact&nbsp;:&nbsp;{phoneNumber}</StyledContact>
-          </Whisper>
+          <StyledContactLine>
+            <Whisper
+              controlId="phone-tooltip"
+              onClick={onCopyPhone}
+              placement="right"
+              speaker={hoverTooltip(tooltipPhoneState.text, tooltipPhoneState.className)}
+              trigger={tooltipPhoneState.trigger as OverlayTriggerType}
+            >
+              <span>
+                <StyledCopyButton
+                  accent={Accent.TERTIARY}
+                  color={COLORS.slateGray}
+                  Icon={Icon.Duplicate}
+                  iconSize={20}
+                />
+              </span>
+            </Whisper>
+            <span>Contact&nbsp;:&nbsp;{phoneNumber}</span>
+          </StyledContactLine>
         )}
         {email && (
-          <Whisper
-            controlId="mail-tooltip"
-            onClick={onCopyMail}
-            placement="right"
-            speaker={hoverTooltip(tooltipMailState.text, tooltipMailState.className)}
-            trigger={tooltipMailState.trigger as OverlayTriggerType}
-          >
-            <StyledContact>{email}</StyledContact>
-          </Whisper>
+          <StyledContactLine>
+            <Whisper
+              controlId="mail-tooltip"
+              onClick={onCopyMail}
+              placement="right"
+              speaker={hoverTooltip(tooltipMailState.text, tooltipMailState.className)}
+              trigger={tooltipMailState.trigger as OverlayTriggerType}
+            >
+              <span>
+                <StyledCopyButton
+                  accent={Accent.TERTIARY}
+                  color={COLORS.slateGray}
+                  Icon={Icon.Duplicate}
+                  iconSize={20}
+                />
+              </span>
+            </Whisper>
+            <span>{email}</span>
+          </StyledContactLine>
         )}
       </StyledContactContainer>
     </Wrapper>
@@ -144,10 +165,19 @@ const StyledContactContainer = styled.div`
   color: ${p => p.theme.color.slateGray};
   white-space: nowrap;
 `
-const StyledContact = styled.span`
-  &:hover {
-    text-decoration: underline;
-    cursor: pointer;
+
+const StyledContactLine = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  align-items: center;
+`
+const StyledCopyButton = styled(IconButton)`
+  padding: 0px;
+  .Element-IconBox {
+    :hover {
+      color: ${p => p.theme.color.blueYonder[100]};
+    }
   }
 `
 

--- a/frontend/src/features/map/overlays/semaphores/SemaphoreCard.tsx
+++ b/frontend/src/features/map/overlays/semaphores/SemaphoreCard.tsx
@@ -89,7 +89,7 @@ export function SemaphoreCard({ feature, selected = false }: { feature: any; sel
             <Whisper
               controlId="phone-tooltip"
               onClick={onCopyPhone}
-              placement="right"
+              placement="left"
               speaker={hoverTooltip(tooltipPhoneState.text, tooltipPhoneState.className)}
               trigger={tooltipPhoneState.trigger as OverlayTriggerType}
             >
@@ -110,7 +110,7 @@ export function SemaphoreCard({ feature, selected = false }: { feature: any; sel
             <Whisper
               controlId="mail-tooltip"
               onClick={onCopyMail}
-              placement="right"
+              placement="left"
               speaker={hoverTooltip(tooltipMailState.text, tooltipMailState.className)}
               trigger={tooltipMailState.trigger as OverlayTriggerType}
             >
@@ -192,10 +192,10 @@ const StyledTooltip = styled(Tooltip)`
     background-color: ${p => p.theme.color.mediumSeaGreen};
   }
 
-  &.rs-tooltip.placement-right:after {
-    border-right-color: ${p => p.theme.color.blueYonder[100]};
+  &.rs-tooltip.placement-left:after {
+    border-left-color: ${p => p.theme.color.blueYonder[100]};
   }
-  &.greenTooltip.rs-tooltip.placement-right:after {
-    border-right-color: ${p => p.theme.color.mediumSeaGreen};
+  &.greenTooltip.rs-tooltip.placement-left:after {
+    border-left-color: ${p => p.theme.color.mediumSeaGreen};
   }
 `

--- a/frontend/src/features/map/overlays/semaphores/index.tsx
+++ b/frontend/src/features/map/overlays/semaphores/index.tsx
@@ -12,11 +12,12 @@ const MARGINS = {
   xRight: -55,
   yBottom: 50,
   yMiddle: 100,
-  yTop: -100
+  yTop: -120
 }
 export function SemaphoreOverlay({ currentFeatureOver, map }: MapChildrenProps) {
   const { selectedSemaphoreId } = useAppSelector(state => state.semaphoresSlice)
   const { displaySemaphoreOverlay } = useAppSelector(state => state.global)
+
   const feature = map
     ?.getLayers()
     ?.getArray()

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -36,7 +36,7 @@ export function HomePage() {
         return (event.returnValue = 'blocked')
       }
 
-      return null
+      return undefined
     },
     [isFormDirty, missionState]
   )

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -29,11 +29,14 @@ export function HomePage() {
 
   const beforeUnload = useCallback(
     event => {
-      event.preventDefault()
       if (isFormDirty && missionState) {
-        // eslint-disable-next-line no-param-reassign
-        event.returnValue = ''
+        event.preventDefault()
+
+        // eslint-disable-next-line no-return-assign, no-param-reassign
+        return (event.returnValue = 'blocked')
       }
+
+      return null
     },
     [isFormDirty, missionState]
   )


### PR DESCRIPTION
- Resolve #465 
lien des retours d'Adeline traités dans cette PR : https://github.com/MTES-MCT/monitorenv/issues/465#issuecomment-1578808624

A noter : 
- vu avec Adeline, lors du zoom sur la carte on enlève le trait reliant la pop-up du sémaphore et le sémaphore de la carte pour éviter un rendu étrange (la ligne ne se met pas à jour)