### PR TITLE
[Mission] Accès à l'édition complète de la mission même si elle est clôturée, résolution du bug de suppression des unités multiples

### DIFF
--- a/frontend/src/features/coordinates/DDCoordinatesInput.tsx
+++ b/frontend/src/features/coordinates/DDCoordinatesInput.tsx
@@ -2,7 +2,6 @@ import { debounce } from 'lodash'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import { COLORS } from '../../constants/constants'
 import { isNumeric } from '../../utils/isNumeric'
 
 type DDCoordinatesInputProps = {
@@ -96,6 +95,7 @@ const DDInput = styled.input`
 
 const CoordinatesType = styled.span`
   margin-left: 7px;
+  color: ${p => p.theme.color.charcoal};
 `
 
 const Error = styled.span`
@@ -108,7 +108,7 @@ const Body = styled.div`
   text-align: left;
 
   input {
-    background: ${COLORS.gainsboro};
+    background: ${p => p.theme.color.gainsboro};
     border: none;
     height: 27px;
     margin-top: 7px;

--- a/frontend/src/features/coordinates/DMDCoordinatesInput.tsx
+++ b/frontend/src/features/coordinates/DMDCoordinatesInput.tsx
@@ -105,6 +105,7 @@ export function DMDCoordinatesInput({ coordinates, coordinatesFormat, updateCoor
 
 const CoordinatesType = styled.span`
   margin-left: 7px;
+  color: ${p => p.theme.color.charcoal};
 `
 
 const Error = styled.span`

--- a/frontend/src/features/coordinates/DMSCoordinatesInput.tsx
+++ b/frontend/src/features/coordinates/DMSCoordinatesInput.tsx
@@ -2,8 +2,6 @@ import { useCallback, useMemo } from 'react'
 import CoordinateInput from 'react-coordinate-input'
 import styled from 'styled-components'
 
-import { COLORS } from '../../constants/constants'
-
 import type { CoordinatesFormat } from '../../domain/entities/map/constants'
 
 type DMSCoordinatesInputProps = {
@@ -43,6 +41,7 @@ export function DMSCoordinatesInput({ coordinates, coordinatesFormat, updateCoor
 
 const CoordinatesType = styled.span`
   margin-left: 7px;
+  color: ${p => p.theme.color.charcoal};
 `
 
 const Body = styled.div`
@@ -50,7 +49,7 @@ const Body = styled.div`
   text-align: left;
 
   input {
-    background: ${COLORS.gainsboro};
+    background: ${p => p.theme.color.gainsboro};
     border: none;
     height: 27px;
     margin-top: 7px;

--- a/frontend/src/features/map/tools/interest_points/EditInterestPoint.tsx
+++ b/frontend/src/features/map/tools/interest_points/EditInterestPoint.tsx
@@ -29,7 +29,6 @@ export function EditInterestPoint({ close, healthcheckTextWarning, isOpen }: Edi
   const dispatch = useAppDispatch()
 
   const { interestPointBeingDrawed, isEditing } = useAppSelector(state => state.interestPoint)
-
   /** Coordinates formatted in DD [latitude, longitude] */
   const coordinates: number[] = useMemo(() => {
     if (!interestPointBeingDrawed?.coordinates?.length) {
@@ -79,7 +78,7 @@ export function EditInterestPoint({ close, healthcheckTextWarning, isOpen }: Edi
 
   const updateType = useCallback(
     type => {
-      if (type && interestPointBeingDrawed?.type !== type && coordinates?.length) {
+      if (type && interestPointBeingDrawed?.type !== type) {
         dispatch(
           updateInterestPointKeyBeingDrawed({
             key: 'type',
@@ -88,7 +87,7 @@ export function EditInterestPoint({ close, healthcheckTextWarning, isOpen }: Edi
         )
       }
     },
-    [dispatch, interestPointBeingDrawed?.type, coordinates]
+    [dispatch, interestPointBeingDrawed?.type]
   )
 
   /**

--- a/frontend/src/features/missions/MissionForm/ActionCard.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionCard.tsx
@@ -19,7 +19,6 @@ type ActionCardProps = {
   action: EnvAction
   duplicateAction: MouseEventHandler
   hasError: boolean
-  readOnly: boolean
   removeAction: MouseEventHandler
   selectAction: MouseEventHandler
   selected: boolean
@@ -29,7 +28,6 @@ export function ActionCard({
   action,
   duplicateAction,
   hasError,
-  readOnly,
   removeAction,
   selectAction,
   selected
@@ -104,24 +102,22 @@ export function ActionCard({
             </>
           )}
 
-          {!readOnly && (
-            <ButtonsWrapper>
-              <IconButton
-                appearance="subtle"
-                icon={<DuplicateSVG className="rs-icon" />}
-                onClick={duplicateAction}
-                size="md"
-                title="dupliquer"
-              />
-              <IconButton
-                appearance="subtle"
-                icon={<DeleteIcon className="rs-icon" />}
-                onClick={removeAction}
-                size="md"
-                title="supprimer"
-              />
-            </ButtonsWrapper>
-          )}
+          <ButtonsWrapper>
+            <IconButton
+              appearance="subtle"
+              icon={<DuplicateSVG className="rs-icon" />}
+              onClick={duplicateAction}
+              size="md"
+              title="dupliquer"
+            />
+            <IconButton
+              appearance="subtle"
+              icon={<DeleteIcon className="rs-icon" />}
+              onClick={removeAction}
+              size="md"
+              title="supprimer"
+            />
+          </ButtonsWrapper>
         </ActionSummaryWrapper>
         {hasError && <ErrorMessage>Veuillez compléter les champs manquants dans cette action</ErrorMessage>}
       </Card>

--- a/frontend/src/features/missions/MissionForm/ActionForm/ActionForm.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ActionForm.tsx
@@ -5,7 +5,7 @@ import { ControlForm } from './ControlForm/ControlForm'
 import { NoteForm } from './NoteForm'
 import { SurveillanceForm } from './SurveillanceForm'
 import { COLORS } from '../../../../constants/constants'
-import { ActionTypeEnum, EnvAction, Mission } from '../../../../domain/entities/missions'
+import { ActionTypeEnum, EnvAction } from '../../../../domain/entities/missions'
 
 type ActionFormProps = {
   currentActionIndex: number | undefined
@@ -15,7 +15,6 @@ type ActionFormProps = {
 export function ActionForm({ currentActionIndex, remove, setCurrentActionIndex }: ActionFormProps) {
   const [actionTypeField] = useField<ActionTypeEnum>(`envActions.${currentActionIndex}.actionType`)
   const [actionIdField] = useField<EnvAction['id']>(`envActions.${currentActionIndex}.id`)
-  const [isClosedField] = useField<Mission['isClosed']>(`isClosed`)
 
   if (currentActionIndex === undefined) {
     return (
@@ -31,7 +30,6 @@ export function ActionForm({ currentActionIndex, remove, setCurrentActionIndex }
           <ControlForm
             key={actionIdField.value}
             currentActionIndex={currentActionIndex}
-            readOnly={isClosedField.value}
             removeControlAction={remove}
             setCurrentActionIndex={setCurrentActionIndex}
           />
@@ -43,7 +41,6 @@ export function ActionForm({ currentActionIndex, remove, setCurrentActionIndex }
           <SurveillanceForm
             key={actionIdField.value}
             currentActionIndex={currentActionIndex}
-            readOnly={isClosedField.value}
             remove={remove}
             setCurrentActionIndex={setCurrentActionIndex}
           />

--- a/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/ControlForm.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/ControlForm.tsx
@@ -25,12 +25,10 @@ import { ActionTheme } from '../Themes/ActionTheme'
 
 export function ControlForm({
   currentActionIndex,
-  readOnly,
   removeControlAction,
   setCurrentActionIndex
 }: {
   currentActionIndex: number
-  readOnly: boolean
   removeControlAction: Function
   setCurrentActionIndex: Function
 }) {
@@ -115,17 +113,16 @@ export function ControlForm({
           &nbsp;(
           {getDateAsLocalizedStringCompact(currentAction?.actionStartDateTimeUtc)})
         </SubTitle>
-        {!readOnly && (
-          <IconButtonRight
-            appearance="ghost"
-            icon={<DeleteIcon className="rs-icon" />}
-            onClick={handleRemoveAction}
-            size="sm"
-            title="supprimer"
-          >
-            Supprimer
-          </IconButtonRight>
-        )}
+
+        <IconButtonRight
+          appearance="ghost"
+          icon={<DeleteIcon className="rs-icon" />}
+          onClick={handleRemoveAction}
+          size="sm"
+          title="supprimer"
+        >
+          Supprimer
+        </IconButtonRight>
       </Header>
       <FormBody>
         <ActionTheme
@@ -148,7 +145,6 @@ export function ControlForm({
           addButtonLabel="Ajouter un point de contrôle"
           label="Lieu du contrôle"
           name={`envActions[${currentActionIndex}].geom`}
-          readOnly={readOnly}
         />
 
         <Separator />

--- a/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/InfractionCard.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/InfractionCard.tsx
@@ -15,8 +15,7 @@ import {
   VesselTypeEnum,
   vesselTypeLabels,
   EnvActionControl,
-  Infraction,
-  Mission
+  Infraction
 } from '../../../../../domain/entities/missions'
 import { ReactComponent as DeleteSVG } from '../../../../../uiMonitor/icons/Delete.svg'
 import { ReactComponent as DuplicateSVG } from '../../../../../uiMonitor/icons/Duplicate.svg'
@@ -45,9 +44,6 @@ export function InfractionCard({
   const [infractionType] = useField<InfractionTypeEnum>(`${infractionPath}.infractionType`)
   const [formalNotice] = useField<FormalNoticeEnum>(`${infractionPath}.formalNotice`)
   const [natinf] = useField<Infraction['natinf']>(`${infractionPath}.natinf`)
-  const [isClosedField] = useField<Mission['isClosed']>(`isClosed`)
-
-  const readOnly = isClosedField.value
 
   let libelleInfractionType
   switch (infractionType?.value) {
@@ -96,21 +92,20 @@ export function InfractionCard({
       </Summary>
       <ButtonsWrapper>
         <IconButton appearance="ghost" icon={<EditIcon className="rs-icon" />} onClick={setCurrentInfractionIndex}>
-          {readOnly ? 'Consulter' : 'Editer'}
+          Editer
         </IconButton>
-        {!readOnly && (
-          <>
-            <IconButton
-              appearance="ghost"
-              data-cy="duplicate-infraction"
-              disabled={!canAddInfraction}
-              icon={<DuplicateSVG className="rs-icon" />}
-              onClick={duplicateInfraction}
-              title="dupliquer"
-            />
-            <IconButton appearance="ghost" icon={<DeleteIcon />} onClick={removeInfraction} />
-          </>
-        )}
+
+        <>
+          <IconButton
+            appearance="ghost"
+            data-cy="duplicate-infraction"
+            disabled={!canAddInfraction}
+            icon={<DuplicateSVG className="rs-icon" />}
+            onClick={duplicateInfraction}
+            title="dupliquer"
+          />
+          <IconButton appearance="ghost" icon={<DeleteIcon />} onClick={removeInfraction} />
+        </>
       </ButtonsWrapper>
     </Wrapper>
   )

--- a/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/InfractionForm/InfractionForm.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/InfractionForm/InfractionForm.tsx
@@ -35,8 +35,6 @@ export function InfractionForm({
 
   const [actionTargetField] = useField<string>(`envActions.${currentActionIndex}.actionTargetType`)
   const [, meta] = useField(infractionPath)
-  const [isClosedField] = useField<boolean>('isClosed')
-  const readOnly = isClosedField.value
 
   return (
     <FormWrapper data-cy="infraction-form">
@@ -94,9 +92,9 @@ export function InfractionForm({
         <FormikTextarea label="Observations" name={`${infractionPath}.observations`} />
       </Form.Group>
       <ButtonToolbarRight>
-        {!readOnly && <Button onClick={removeInfraction}>Supprimer l&apos;infraction</Button>}
+        <Button onClick={removeInfraction}>Supprimer l&apos;infraction</Button>
         <Button appearance="primary" data-cy="infraction-form-validate" onClick={validateInfraction}>
-          {readOnly ? "Fermer l'infraction" : "Valider l'infraction"}
+          Valider l&apos;infraction
         </Button>
       </ButtonToolbarRight>
       {!!meta.error && (

--- a/frontend/src/features/missions/MissionForm/ActionForm/SurveillanceForm.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/SurveillanceForm.tsx
@@ -15,7 +15,7 @@ import { dateDifferenceInHours } from '../../../../utils/dateDifferenceInHours'
 import { pluralize } from '../../../../utils/pluralize'
 import { MultiZonePicker } from '../../MultiZonePicker'
 
-export function SurveillanceForm({ currentActionIndex, readOnly, remove, setCurrentActionIndex }) {
+export function SurveillanceForm({ currentActionIndex, remove, setCurrentActionIndex }) {
   const { newWindowContainerRef } = useNewWindow()
 
   const [, actionStartDateMeta] = useField(`envActions[${currentActionIndex}].actionStartDateTimeUtc`)
@@ -116,7 +116,6 @@ export function SurveillanceForm({ currentActionIndex, readOnly, remove, setCurr
           isLight
           label="Zone de surveillance"
           name={`envActions[${currentActionIndex}].geom`}
-          readOnly={readOnly}
         />
         <StyledFormikCheckbox
           disabled={hasCustomZone || isEditingZone}

--- a/frontend/src/features/missions/MissionForm/ActionsForm.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionsForm.tsx
@@ -15,7 +15,6 @@ import { actionFactory } from '../Missions.helpers'
 export function ActionsForm({ currentActionIndex, form, remove, setCurrentActionIndex, unshift }) {
   const envActions = form?.values?.envActions as EnvAction[] | undefined
   const isFirstSurveillanceAction = !envActions?.find(action => action.actionType === ActionTypeEnum.SURVEILLANCE)
-  const isClosed = form?.values?.isClosed
   const currentActionId = envActions && envActions[currentActionIndex]?.id
 
   const sortedEnvActions = useMemo(
@@ -81,19 +80,17 @@ export function ActionsForm({ currentActionIndex, form, remove, setCurrentAction
     <FormWrapper>
       <TitleWrapper>
         <Title>Actions réalisées en mission</Title>
-        {!isClosed && (
-          <Dropdown appearance="primary" icon={<PlusSVG className="rs-icon" />} noCaret title="Ajouter">
-            <Dropdown.Item icon={<ControlSVG />} onClick={handleAddControlAction}>
-              Ajouter des contrôles
-            </Dropdown.Item>
-            <Dropdown.Item icon={<SurveillanceSVG />} onClick={handleAddSurveillanceAction}>
-              Ajouter une surveillance
-            </Dropdown.Item>
-            <Dropdown.Item icon={<NoteSVG />} onClick={handleAddNoteAction}>
-              Ajouter une note libre
-            </Dropdown.Item>
-          </Dropdown>
-        )}
+        <Dropdown appearance="primary" icon={<PlusSVG className="rs-icon" />} noCaret title="Ajouter">
+          <Dropdown.Item icon={<ControlSVG />} onClick={handleAddControlAction}>
+            Ajouter des contrôles
+          </Dropdown.Item>
+          <Dropdown.Item icon={<SurveillanceSVG />} onClick={handleAddSurveillanceAction}>
+            Ajouter une surveillance
+          </Dropdown.Item>
+          <Dropdown.Item icon={<NoteSVG />} onClick={handleAddNoteAction}>
+            Ajouter une note libre
+          </Dropdown.Item>
+        </Dropdown>
       </TitleWrapper>
       <ActionsTimeline>
         {sortedEnvActions && sortedEnvActions.length > 0 ? (
@@ -108,7 +105,6 @@ export function ActionsForm({ currentActionIndex, form, remove, setCurrentAction
                 action={action}
                 duplicateAction={handleDuplicateAction(action.id)}
                 hasError={!!errors}
-                readOnly={isClosed}
                 removeAction={handleRemoveAction(action.id)}
                 selectAction={handleSelectAction(action.id)}
                 selected={action.id === currentActionId}

--- a/frontend/src/features/missions/MissionForm/ControlUnitSelector.tsx
+++ b/frontend/src/features/missions/MissionForm/ControlUnitSelector.tsx
@@ -203,5 +203,5 @@ const StyledAdministartionContainer = styled.div`
 const DeleteButton = styled(IconButton)`
   position: absolute;
   top: 0px;
-  left: 425px;
+  left: calc(100% + 4px);
 `

--- a/frontend/src/features/missions/MissionForm/ControlUnitsForm.tsx
+++ b/frontend/src/features/missions/MissionForm/ControlUnitsForm.tsx
@@ -3,7 +3,7 @@ import { Accent, Button, Icon, Size } from '@mtes-mct/monitor-ui'
 import { ControlUnitSelector } from './ControlUnitSelector'
 import { controlUnitFactory } from '../Missions.helpers'
 
-export function ControlUnitsForm({ form, push, readOnly, remove }) {
+export function ControlUnitsForm({ form, push, remove }) {
   const handleAddControlUnit = () => {
     push(controlUnitFactory())
   }
@@ -27,11 +27,10 @@ export function ControlUnitsForm({ form, push, readOnly, remove }) {
           ))}
         </>
       )}
-      {!readOnly && (
-        <Button accent={Accent.SECONDARY} Icon={Icon.Plus} onClick={handleAddControlUnit} size={Size.SMALL}>
-          Ajouter une autre unité
-        </Button>
-      )}
+
+      <Button accent={Accent.SECONDARY} Icon={Icon.Plus} onClick={handleAddControlUnit} size={Size.SMALL}>
+        Ajouter une autre unité
+      </Button>
     </div>
   )
 }

--- a/frontend/src/features/missions/MissionForm/GeneralInformationsForm.tsx
+++ b/frontend/src/features/missions/MissionForm/GeneralInformationsForm.tsx
@@ -31,16 +31,12 @@ import { MultiZonePicker } from '../MultiZonePicker'
 export function GeneralInformationsForm() {
   const { newWindowContainerRef } = useNewWindow()
 
-  const [isClosedField] = useField<boolean>('isClosed')
   const [hasMissionOrderField] = useField<boolean>('hasMissionOrder')
   const [missionSourceField] = useField<MissionSourceEnum>('missionSource')
-  const { values } = useFormikContext<Mission>()
+  const { errors, values } = useFormikContext<Mission>()
   const missionTypeOptions = Object.entries(missionTypeEnum).map(([key, val]) => ({ label: val.libelle, value: key }))
 
   const hasMissionOrderOptions = Object.values(hasMissionOrderLabels)
-
-  const [, startDateMeta] = useField('startDateTimeUtc')
-  const [, endDateMeta] = useField('endDateTimeUtc')
 
   const { sideWindow } = useAppSelector(state => state)
   const routeParams = getMissionPageRoute(sideWindow.currentPath)
@@ -86,8 +82,8 @@ export function GeneralInformationsForm() {
               withTime
             />
           </StyledDatePickerContainer>
-          {startDateMeta.error && <FieldError>{startDateMeta.error}</FieldError>}
-          {endDateMeta.error && <FieldError>{endDateMeta.error}</FieldError>}
+          {errors.startDateTimeUtc && <FieldError>{errors.startDateTimeUtc}</FieldError>}
+          {errors.endDateTimeUtc && <FieldError>{errors.endDateTimeUtc}</FieldError>}
         </div>
 
         <StyledMissionType>
@@ -120,7 +116,7 @@ export function GeneralInformationsForm() {
           <FieldArray
             name="controlUnits"
             /* eslint-disable-next-line react/jsx-props-no-spreading */
-            render={props => <ControlUnitsForm readOnly={isClosedField.value} {...props} />}
+            render={props => <ControlUnitsForm {...props} />}
             validateOnChange={false}
           />
         </StyledUnitsContainer>
@@ -130,7 +126,6 @@ export function GeneralInformationsForm() {
           interactionListener={InteractionListener.MISSION_ZONE}
           label="Localisations :"
           name="geom"
-          readOnly={isClosedField.value}
         />
 
         <StyledObservationsContainer>
@@ -140,6 +135,8 @@ export function GeneralInformationsForm() {
             <FormikTextInput isErrorMessageHidden label="Ouvert par" name="openBy" />
             <FormikTextInput isErrorMessageHidden label="Clôturé par" name="closedBy" />
           </StyledAuthorContainer>
+          {errors.openBy && <FieldError>{errors.openBy}</FieldError>}
+          {errors.closedBy && <FieldError>{errors.closedBy}</FieldError>}
         </StyledObservationsContainer>
       </StyledFormWrapper>
     </StyledContainer>

--- a/frontend/src/features/missions/MissionForm/MissionForm.tsx
+++ b/frontend/src/features/missions/MissionForm/MissionForm.tsx
@@ -24,7 +24,7 @@ import { useAppSelector } from '../../../hooks/useAppSelector'
 import { useSyncFormValuesWithRedux } from '../../../hooks/useSyncFormValuesWithRedux'
 import { sideWindowActions } from '../../SideWindow/slice'
 
-export function MissionForm({ id, isNewMission, selectedMission, setShouldValidateOnChange }) {
+export function MissionForm({ id, isAlreadyClosed, isNewMission, selectedMission, setShouldValidateOnChange }) {
   const dispatch = useDispatch()
   const { sideWindow } = useAppSelector(state => state)
   const { dirty, handleSubmit, setFieldValue, setValues, validateForm, values } =
@@ -74,6 +74,13 @@ export function MissionForm({ id, isNewMission, selectedMission, setShouldValida
   }
 
   const submitMission = async () => {
+    setShouldValidateOnChange(false)
+
+    // If the mission is not already closed (from the API), we want the `isClosed` field to be set to false.
+    // if the user has already tried to close the mission and the `isClosed` field is set to true.
+    if (!isAlreadyClosed) {
+      await setFieldValue('isClosed', false)
+    }
     validateForm().then(errors => {
       if (_.isEmpty(errors)) {
         handleSubmit()

--- a/frontend/src/features/missions/MissionForm/Schemas/index.ts
+++ b/frontend/src/features/missions/MissionForm/Schemas/index.ts
@@ -97,7 +97,8 @@ const NewMissionSchema: Yup.SchemaOf<NewMission> = Yup.object()
     openBy: Yup.string()
       .min(3, 'le Trigramme doit comporter 3 lettres')
       .max(3, 'le Trigramme doit comporter 3 lettres')
-      .required('Requis'),
+      .nullable()
+      .required('Trigramme requis'),
     startDateTimeUtc: Yup.date().required('Date de début requise')
   })
   .required()
@@ -106,7 +107,8 @@ const ClosedMissionSchema = NewMissionSchema.shape({
   closedBy: Yup.string()
     .min(3, 'Minimum 3 lettres pour le Trigramme')
     .max(3, 'Maximum 3 lettres pour le Trigramme')
-    .required('Requis'),
+    .nullable()
+    .required('Trigramme requis'),
   controlUnits: Yup.array().of(ClosedControlUnitSchema).ensure().defined().min(1),
   endDateTimeUtc: Yup.date()
     .nullable()

--- a/frontend/src/features/missions/MissionForm/index.tsx
+++ b/frontend/src/features/missions/MissionForm/index.tsx
@@ -69,6 +69,7 @@ export function Mission() {
         <FormikForm>
           <MissionForm
             id={idTyped}
+            isAlreadyClosed={missionToEdit?.isClosed}
             isNewMission={missionIsNewMission}
             selectedMission={selectedMission?.mission}
             setShouldValidateOnChange={setShouldValidateOnChange}

--- a/frontend/src/features/missions/MultiPointPicker.tsx
+++ b/frontend/src/features/missions/MultiPointPicker.tsx
@@ -27,9 +27,8 @@ export type MultiPointPickerProps = {
   addButtonLabel: string
   label: string
   name: string
-  readOnly: boolean
 }
-export function MultiPointPicker({ addButtonLabel, label, name, readOnly }: MultiPointPickerProps) {
+export function MultiPointPicker({ addButtonLabel, label, name }: MultiPointPickerProps) {
   const dispatch = useAppDispatch()
   const listener = useAppSelector(state => state.draw.listener)
   const { coordinatesFormat } = useAppSelector(state => state.map)
@@ -92,17 +91,16 @@ export function MultiPointPicker({ addButtonLabel, label, name, readOnly }: Mult
   return (
     <Field>
       <Label>{label}</Label>
-      {!readOnly && (
-        <Button
-          accent={Accent.SECONDARY}
-          disabled={points.length > 0}
-          Icon={Icon.Plus}
-          isFullWidth
-          onClick={handleAddPoint}
-        >
-          {addButtonLabel}
-        </Button>
-      )}
+
+      <Button
+        accent={Accent.SECONDARY}
+        disabled={points.length > 0}
+        Icon={Icon.Plus}
+        isFullWidth
+        onClick={handleAddPoint}
+      >
+        {addButtonLabel}
+      </Button>
 
       <>
         {points.map((coordinates, index) => (
@@ -120,23 +118,21 @@ export function MultiPointPicker({ addButtonLabel, label, name, readOnly }: Mult
               </Center>
             </ZoneWrapper>
 
-            {!readOnly && (
-              <>
-                <IconButton
-                  accent={Accent.SECONDARY}
-                  disabled={isAddingAControl}
-                  Icon={Icon.Edit}
-                  onClick={handleAddPoint}
-                />
-                <IconButton
-                  accent={Accent.SECONDARY}
-                  aria-label="Supprimer cette zone"
-                  disabled={isAddingAControl}
-                  Icon={Icon.Delete}
-                  onClick={() => handleDeleteZone(index)}
-                />
-              </>
-            )}
+            <>
+              <IconButton
+                accent={Accent.SECONDARY}
+                disabled={isAddingAControl}
+                Icon={Icon.Edit}
+                onClick={handleAddPoint}
+              />
+              <IconButton
+                accent={Accent.SECONDARY}
+                aria-label="Supprimer cette zone"
+                disabled={isAddingAControl}
+                Icon={Icon.Delete}
+                onClick={() => handleDeleteZone(index)}
+              />
+            </>
           </Row>
         ))}
       </>

--- a/frontend/src/features/missions/MultiZonePicker.tsx
+++ b/frontend/src/features/missions/MultiZonePicker.tsx
@@ -29,7 +29,6 @@ export type MultiZonePickerProps = {
   isLight?: boolean
   label: string
   name: string
-  readOnly: boolean
 }
 export function MultiZonePicker({
   addButtonLabel,
@@ -37,8 +36,7 @@ export function MultiZonePicker({
   interactionListener,
   isLight,
   label,
-  name,
-  readOnly
+  name
 }: MultiZonePickerProps) {
   const dispatch = useAppDispatch()
   const { geometry } = useListenForDrawedGeometry(interactionListener)
@@ -96,11 +94,11 @@ export function MultiZonePicker({
   return (
     <Field>
       <Label hasError={!!meta.error}>{label}</Label>
-      {!readOnly && (
-        <Button accent={Accent.SECONDARY} Icon={Icon.Plus} isFullWidth onClick={handleAddZone}>
-          {addButtonLabel}
-        </Button>
-      )}
+
+      <Button accent={Accent.SECONDARY} Icon={Icon.Plus} isFullWidth onClick={handleAddZone}>
+        {addButtonLabel}
+      </Button>
+
       {!!meta.error && <ErrorMessage>Veuillez définir une zone de mission</ErrorMessage>}
 
       <>
@@ -119,23 +117,16 @@ export function MultiZonePicker({
               </Center>
             </ZoneWrapper>
 
-            {!readOnly && (
-              <>
-                <IconButton
-                  accent={Accent.SECONDARY}
-                  disabled={isEditingZone}
-                  Icon={Icon.Edit}
-                  onClick={handleAddZone}
-                />
-                <IconButton
-                  accent={Accent.SECONDARY}
-                  aria-label="Supprimer cette zone"
-                  disabled={isEditingZone}
-                  Icon={Icon.Delete}
-                  onClick={() => deleteZone(index)}
-                />
-              </>
-            )}
+            <>
+              <IconButton accent={Accent.SECONDARY} disabled={isEditingZone} Icon={Icon.Edit} onClick={handleAddZone} />
+              <IconButton
+                accent={Accent.SECONDARY}
+                aria-label="Supprimer cette zone"
+                disabled={isEditingZone}
+                Icon={Icon.Delete}
+                onClick={() => deleteZone(index)}
+              />
+            </>
           </Row>
         ))}
       </>


### PR DESCRIPTION
- Resolve #528 (On garde la possibilité d'éditer la zone de mission et d'ajouter des actions même si la mission est clôturée)
- Résolution du bug qui masquait la poubelle au niveau des unités (en cas de multiples unités)
- Affichage du format des coordonnées en plus foncé (fenêtre d'édition d'un point de contrôle)