### PR TITLE
[Map] Ajout de la possibilité de changer l'unité de distance (mètres/kms ou nautiques)

### DIFF
--- a/frontend/src/domain/entities/map/constants.ts
+++ b/frontend/src/domain/entities/map/constants.ts
@@ -30,6 +30,11 @@ export enum CoordinatesFormat {
   DEGREES_MINUTES_SECONDS = 'DMS'
 }
 
+export enum DistanceUnit {
+  METRIC = 'metric',
+  NAUTICAL = 'nautical'
+}
+
 export enum MapToolType {
   FILTERS = 'FILTERS',
   INTEREST_POINT = 'INTEREST_POINT',

--- a/frontend/src/domain/shared_slices/Map.ts
+++ b/frontend/src/domain/shared_slices/Map.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 
 import { BaseLayers } from '../entities/layers/constants'
-import { CoordinatesFormat } from '../entities/map/constants'
+import { CoordinatesFormat, DistanceUnit } from '../entities/map/constants'
 
 import type { Coordinate } from 'ol/coordinate'
 import type { Extent } from 'ol/extent'
@@ -9,6 +9,7 @@ import type { Extent } from 'ol/extent'
 type MapSliceStateType = {
   coordinatesFormat: CoordinatesFormat
   currentMapExtentTracker?: number[]
+  distanceUnit: DistanceUnit
   fitToExtent?: Extent
   selectedBaseLayer: string
   zoomToCenter?: Coordinate
@@ -16,6 +17,7 @@ type MapSliceStateType = {
 const initialState: MapSliceStateType = {
   coordinatesFormat: CoordinatesFormat.DEGREES_MINUTES_SECONDS,
   currentMapExtentTracker: undefined,
+  distanceUnit: DistanceUnit.NAUTICAL,
   fitToExtent: undefined,
   selectedBaseLayer: BaseLayers.LIGHT.code,
   zoomToCenter: undefined
@@ -50,6 +52,16 @@ const mapSlice = createSlice({
     },
 
     /**
+     * Set the distance unit in the whole application (as metrics, nautical)
+     * @param {Object} state
+     * @param {{
+     * payload: DistanceUnit}} action - The distance unit
+     */
+    setDistanceUnit(state, action) {
+      state.distanceUnit = action.payload
+    },
+
+    /**
      *
      * @param {*} state
      * @param {object} action.payload.extent
@@ -64,7 +76,13 @@ const mapSlice = createSlice({
   }
 })
 
-export const { selectBaseLayer, setCoordinatesFormat, setCurrentMapExtentTracker, setFitToExtent, setZoomToCenter } =
-  mapSlice.actions
+export const {
+  selectBaseLayer,
+  setCoordinatesFormat,
+  setCurrentMapExtentTracker,
+  setDistanceUnit,
+  setFitToExtent,
+  setZoomToCenter
+} = mapSlice.actions
 
 export const mapSliceReducer = mapSlice.reducer

--- a/frontend/src/domain/shared_slices/Measurement.ts
+++ b/frontend/src/domain/shared_slices/Measurement.ts
@@ -92,6 +92,9 @@ const measurementSlice = createSlice({
       state.circleMeasurementToAdd = action.payload
     },
 
+    setMeasurementDrawedDistanceUnit(state, action) {
+      state.measurementsDrawed = action.payload
+    },
     setMeasurementTypeToAdd(state, action) {
       state.measurementTypeToAdd = action.payload
     }
@@ -106,6 +109,7 @@ export const {
   resetMeasurementTypeToAdd,
   setCircleMeasurementInDrawing,
   setCircleMeasurementToAdd,
+  setMeasurementDrawedDistanceUnit,
   setMeasurementTypeToAdd
 } = measurementSlice.actions
 

--- a/frontend/src/domain/use_cases/map/updateMeasurementsWithNewDistanceUnit.ts
+++ b/frontend/src/domain/use_cases/map/updateMeasurementsWithNewDistanceUnit.ts
@@ -1,0 +1,28 @@
+import { getNauticalMilesFromMeters } from '../../../utils/utils'
+import { DistanceUnit } from '../../entities/map/constants'
+import { setMeasurementDrawedDistanceUnit } from '../../shared_slices/Measurement'
+
+export const updateMeasurementsWithNewDistanceUnit = () => (dispatch, getState) => {
+  const {
+    map: { distanceUnit: globalDistanceUnit },
+    measurement: { measurementsDrawed }
+  } = getState()
+
+  const metersForOneNauticalMile = 1852
+
+  const newDrawedMeasurements = measurementsDrawed.map(drawedMeasurement => {
+    const { distanceUnit = DistanceUnit.NAUTICAL, measurement } = drawedMeasurement
+
+    if (globalDistanceUnit === DistanceUnit.NAUTICAL) {
+      const newMeasurement =
+        distanceUnit === DistanceUnit.METRIC ? getNauticalMilesFromMeters(measurement) : measurement
+
+      return { ...drawedMeasurement, distanceUnit: globalDistanceUnit, measurement: newMeasurement }
+    }
+
+    const newMeasurement = distanceUnit === DistanceUnit.NAUTICAL ? measurement * metersForOneNauticalMile : measurement
+
+    return { ...drawedMeasurement, distanceUnit: globalDistanceUnit, measurement: newMeasurement }
+  })
+  dispatch(setMeasurementDrawedDistanceUnit(newDrawedMeasurements))
+}

--- a/frontend/src/domain/use_cases/measurement/saveMeasurement.ts
+++ b/frontend/src/domain/use_cases/measurement/saveMeasurement.ts
@@ -6,7 +6,9 @@ import { batch } from 'react-redux'
 import { DistanceUnit, OPENLAYERS_PROJECTION } from '../../entities/map/constants'
 import { addMeasurementDrawed, resetCircleMeasurementInDrawing } from '../../shared_slices/Measurement'
 
-export const saveMeasurement = (feature, measurement, distanceUnit) => dispatch => {
+export const saveMeasurement = (feature, measurement) => (dispatch, getState) => {
+  const { distanceUnit } = getState().map
+
   feature.setId(feature.ol_uid)
 
   if (feature.getGeometry() instanceof Circle) {

--- a/frontend/src/domain/use_cases/measurement/saveMeasurement.ts
+++ b/frontend/src/domain/use_cases/measurement/saveMeasurement.ts
@@ -3,10 +3,10 @@ import Circle from 'ol/geom/Circle'
 import { fromCircle } from 'ol/geom/Polygon'
 import { batch } from 'react-redux'
 
-import { OPENLAYERS_PROJECTION } from '../../entities/map/constants'
+import { DistanceUnit, OPENLAYERS_PROJECTION } from '../../entities/map/constants'
 import { addMeasurementDrawed, resetCircleMeasurementInDrawing } from '../../shared_slices/Measurement'
 
-export const saveMeasurement = (feature, measurement) => dispatch => {
+export const saveMeasurement = (feature, measurement, distanceUnit) => dispatch => {
   feature.setId(feature.ol_uid)
 
   if (feature.getGeometry() instanceof Circle) {
@@ -20,6 +20,7 @@ export const saveMeasurement = (feature, measurement) => dispatch => {
     dispatch(
       addMeasurementDrawed({
         coordinates: tooltipCoordinates,
+        distanceUnit: distanceUnit || DistanceUnit.NAUTICAL,
         feature: geoJSONFeature,
         measurement
       })

--- a/frontend/src/features/map/controls/MapCoordinatesBox.tsx
+++ b/frontend/src/features/map/controls/MapCoordinatesBox.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { Radio, RadioGroup } from 'rsuite'
 import styled from 'styled-components'
 
-import { COLORS } from '../../../constants/constants'
 import { CoordinatesFormat, OPENLAYERS_PROJECTION } from '../../../domain/entities/map/constants'
 import { setCoordinatesFormat } from '../../../domain/shared_slices/Map'
 import { useAppDispatch } from '../../../hooks/useAppDispatch'
@@ -119,7 +118,7 @@ const RadioWrapper = styled(RadioGroup)`
 `
 
 const Header = styled.span`
-  background-color: ${COLORS.charcoal};
+  background-color: ${p => p.theme.color.charcoal};
   color: ${p => p.theme.color.gainsboro};
   padding: 5px 0;
   width: 100%;
@@ -136,14 +135,9 @@ const CoordinatesTypeSelection = styled.span<{ isOpen: boolean }>`
   left: 40px;
   display: inline-block;
   margin: 1px;
-  color: ${COLORS.slateGray};
-  font-size: 13px;
-  font-weight: 300;
-  text-decoration: none;
+  color: ${p => p.theme.color.slateGray};
   text-align: center;
-  background-color: ${COLORS.white};
-  border: none;
-  border-radius: 2px;
+  background-color: ${p => p.theme.color.white};
   width: 237px;
   opacity: ${props => (props.isOpen ? 1 : 0)};
   visibility: ${props => (props.isOpen ? 'visible' : 'hidden')};
@@ -160,14 +154,9 @@ const Coordinates = styled.span`
   display: inline-block;
   padding: 2px 0 6px 2px;
   color: ${p => p.theme.color.gainsboro};
-  font-size: 13px;
-  font-weight: 300;
-  text-decoration: none;
   text-align: center;
   height: 17px;
-  background-color: ${COLORS.charcoal};
-  border: none;
-  border-radius: 2px;
+  background-color: ${p => p.theme.color.charcoal};
   width: 235px;
   cursor: pointer;
 `

--- a/frontend/src/features/map/layers/MeasurementLayer.tsx
+++ b/frontend/src/features/map/layers/MeasurementLayer.tsx
@@ -199,7 +199,7 @@ export function MeasurementLayer({ map }: BaseMapChildrenProps) {
       })
 
       draw.on(DRAW_END_EVENT, event => {
-        dispatch(saveMeasurement(event.feature, measurementInProgressRef.current?.measurement, distanceUnit))
+        dispatch(saveMeasurement(event.feature, measurementInProgressRef.current?.measurement))
         unByKey(listener)
         dispatch(resetMeasurementTypeToAdd())
         setMeasurementInProgress(null)
@@ -212,7 +212,9 @@ export function MeasurementLayer({ map }: BaseMapChildrenProps) {
       addEmptyNextMeasurement()
       drawNewFeatureOnMap()
     }
-  }, [dispatch, map, measurementTypeToAdd, distanceUnit])
+    // we don't want to draw  multiple circle if the user changes the distance unit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, map, measurementTypeToAdd])
 
   useEffect(() => {
     if (!measurementTypeToAdd) {
@@ -272,7 +274,7 @@ export function MeasurementLayer({ map }: BaseMapChildrenProps) {
         style: [measurementStyle, measurementStyleWithCenter]
       })
 
-      dispatch(saveMeasurement(circleFeature, circleMeasurementToAdd?.circleRadiusToAdd, distanceUnit))
+      dispatch(saveMeasurement(circleFeature, circleMeasurementToAdd?.circleRadiusToAdd))
     }
 
     addCustomCircleMeasurement()

--- a/frontend/src/features/map/tools/measurements/CustomCircleRange.tsx
+++ b/frontend/src/features/map/tools/measurements/CustomCircleRange.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { COLORS } from '../../../../constants/constants'
 import {
   CoordinatesFormat,
+  DistanceUnit,
   MeasurementType,
   OPENLAYERS_PROJECTION,
   WSG84_PROJECTION
@@ -26,6 +27,7 @@ export function CustomCircleRange() {
   const dispatch = useAppDispatch()
   const { circleMeasurementInDrawing, measurementTypeToAdd } = useAppSelector(state => state.measurement)
   const { healthcheckTextWarning } = useAppSelector(state => state.global)
+  const { distanceUnit } = useAppSelector(state => state.map)
 
   const circleCoordinates = useMemo(() => {
     if (measurementTypeToAdd !== MeasurementType.CIRCLE_RANGE || !circleMeasurementInDrawing?.coordinates?.length) {
@@ -117,7 +119,7 @@ export function CustomCircleRange() {
           type="text"
           value={circleRadius}
         />
-        <span>(Nm)</span>
+        <span>{distanceUnit === DistanceUnit.METRIC ? '(Km)' : '(Nm)'}</span>
         <br />
         <OkButton
           data-cy="measurement-circle-add"

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -17,17 +17,8 @@ const homeStore = configureStore({
       // TODO Create a Redux middleware to properly serialize/deserialize `Date`, `Error` objects into plain objects.
       // https://redux-toolkit.js.org/api/serializabilityMiddleware
       serializableCheck: {
-        ignoredActions: [
-          FLUSH,
-          REHYDRATE,
-          PAUSE,
-          PERSIST,
-          PURGE,
-          REGISTER,
-          'regulatory/setRegulatoryLayers',
-          'measurement/addMeasurementDrawed'
-        ],
-        ignoredPaths: ['regulatory', 'layerSearch', 'measurement.measurementsDrawed'],
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER, 'regulatory/setRegulatoryLayers'],
+        ignoredPaths: ['regulatory', 'layerSearch'],
         isSerializable: (value: any) => isPlain(value) || value instanceof Date || value instanceof Error
       }
     }).concat(homeMiddlewares),

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -17,8 +17,17 @@ const homeStore = configureStore({
       // TODO Create a Redux middleware to properly serialize/deserialize `Date`, `Error` objects into plain objects.
       // https://redux-toolkit.js.org/api/serializabilityMiddleware
       serializableCheck: {
-        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER, 'regulatory/setRegulatoryLayers'],
-        ignoredPaths: ['regulatory', 'layerSearch'],
+        ignoredActions: [
+          FLUSH,
+          REHYDRATE,
+          PAUSE,
+          PERSIST,
+          PURGE,
+          REGISTER,
+          'regulatory/setRegulatoryLayers',
+          'measurement/addMeasurementDrawed'
+        ],
+        ignoredPaths: ['regulatory', 'layerSearch', 'measurement.measurementsDrawed'],
         isSerializable: (value: any) => isPlain(value) || value instanceof Date || value instanceof Error
       }
     }).concat(homeMiddlewares),


### PR DESCRIPTION
- Resolve #34 

Ajout d'un sélecteur pour changer les unités de distance
Répercussion sur l'outil de tracé d'un point ou d'une ligne (même comportement que pour les unité de coordonnées)