### PR TITLE
[Moyens et unités] Ajout de la dialog d'impossibilité de suppression de moyens liés à des missions

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IMissionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IMissionRepository.kt
@@ -39,5 +39,7 @@ interface IMissionRepository {
 
     fun findByControlUnitId(controlUnitId: Int): List<MissionEntity>
 
+    fun findByControlUnitResourceId(controlUnitResourceId: Int): List<MissionEntity>
+
     fun save(mission: MissionEntity): MissionDTO
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResource.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResource.kt
@@ -7,8 +7,8 @@ import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
 class CanDeleteControlUnitResource(
     private val missionRepository: IMissionRepository,
 ) {
-    fun execute(controlUnitId: Int): Boolean {
-        val missions = missionRepository.findByControlUnitId(controlUnitId)
+    fun execute(controlUnitResourceId: Int): Boolean {
+        val missions = missionRepository.findByControlUnitResourceId(controlUnitResourceId)
 
         return missions.isEmpty()
     }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResource.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResource.kt
@@ -1,0 +1,15 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import fr.gouv.cacem.monitorenv.config.UseCase
+import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
+
+@UseCase
+class CanDeleteControlUnitResource(
+    private val missionRepository: IMissionRepository,
+) {
+    fun execute(controlUnitId: Int): Boolean {
+        val missions = missionRepository.findByControlUnitId(controlUnitId)
+
+        return missions.isEmpty()
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitResource.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitResource.kt
@@ -2,10 +2,20 @@ package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
 
 import fr.gouv.cacem.monitorenv.config.UseCase
 import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitResourceRepository
+import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.exceptions.ForeignKeyConstraintException
 
 @UseCase
-class DeleteControlUnitResource(private val controlUnitResourceRepository: IControlUnitResourceRepository) {
+class DeleteControlUnitResource(
+    private val canDeleteControlUnitResource: CanDeleteControlUnitResource,
+    private val controlUnitResourceRepository: IControlUnitResourceRepository,
+) {
     fun execute(controlUnitResourceId: Int) {
+        if (!canDeleteControlUnitResource.execute(controlUnitResourceId)) {
+            throw ForeignKeyConstraintException(
+                "Cannot delete control unit resource (ID=$controlUnitResourceId) due to existing relationships.",
+            )
+        }
+
         return controlUnitResourceRepository.deleteById(controlUnitResourceId)
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiControlUnitResourcesController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiControlUnitResourcesController.kt
@@ -2,6 +2,7 @@ package fr.gouv.cacem.monitorenv.infrastructure.api.endpoints.publicapi
 
 import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.*
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.publicapi.inputs.CreateOrUpdateControlUnitResourceDataInput
+import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.publicapi.outputs.BooleanDataOutput
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.publicapi.outputs.ControlUnitResourceDataOutput
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.publicapi.outputs.FullControlUnitResourceDataOutput
 import io.swagger.v3.oas.annotations.Operation
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*
 @Tag(name = "Control Unit Resources")
 class ApiControlUnitResourcesController(
     private val archiveControlUnitResource: ArchiveControlUnitResource,
+    private val canDeleteControlUnitResource: CanDeleteControlUnitResource,
     private val createOrUpdateControlUnitResource: CreateOrUpdateControlUnitResource,
     private val deleteControlUnitResource: DeleteControlUnitResource,
     private val getControlUnitResources: GetControlUnitResources,
@@ -28,6 +30,16 @@ class ApiControlUnitResourcesController(
         controlUnitResourceId: Int,
     ) {
         archiveControlUnitResource.execute(controlUnitResourceId)
+    }
+
+    @GetMapping("/{controlUnitResourceId}/can_delete")
+    @Operation(summary = "Can this control unit resource be deleted?")
+    fun canDelete(
+        @PathParam("Control unit resource ID")
+        @PathVariable(name = "controlUnitResourceId")
+        controlUnitResourceId: Int,
+    ): BooleanDataOutput {
+        return canDeleteControlUnitResource.execute(controlUnitResourceId).let { BooleanDataOutput.get(it) }
     }
 
     @PostMapping("", consumes = ["application/json"])

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaMissionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaMissionRepository.kt
@@ -60,6 +60,12 @@ class JpaMissionRepository(
         }
     }
 
+    override fun findByControlUnitResourceId(controlUnitResourceId: Int): List<MissionEntity> {
+        return dbMissionRepository.findByControlUnitResourceId(controlUnitResourceId).map {
+            it.toMissionEntity(mapper)
+        }
+    }
+
     override fun findAll(
         startedAfter: Instant,
         startedBefore: Instant?,

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/interfaces/IDBMissionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/interfaces/IDBMissionRepository.kt
@@ -95,4 +95,9 @@ interface IDBMissionRepository : JpaRepository<MissionModel, Int> {
 
     @Query("SELECT mm FROM MissionModel mm JOIN mm.controlUnits mmcu WHERE mmcu.unit.id = :controlUnitId")
     fun findByControlUnitId(controlUnitId: Int): List<MissionModel>
+
+    @Query(
+        "SELECT mm FROM MissionModel mm JOIN mm.controlResources mmcr WHERE mmcr.resource.id = :controlUnitResourceId",
+    )
+    fun findByControlUnitResourceId(controlUnitResourceId: Int): List<MissionModel>
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/ArchiveAdministrationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/ArchiveAdministrationUTests.kt
@@ -1,0 +1,46 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.administration
+
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import fr.gouv.cacem.monitorenv.domain.repositories.IAdministrationRepository
+import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.exceptions.UnarchivedChildException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class ArchiveAdministrationUTests {
+    @MockBean
+    private lateinit var administrationRepository: IAdministrationRepository
+
+    @MockBean
+    private lateinit var canArchiveAdministration: CanArchiveAdministration
+
+    @Test
+    fun `execute should archive when canArchive returns true`() {
+        val administrationId = 1
+
+        given(canArchiveAdministration.execute(administrationId)).willReturn(true)
+
+        ArchiveAdministration(administrationRepository, canArchiveAdministration).execute(administrationId)
+
+        verify(administrationRepository).archiveById(administrationId)
+    }
+
+    @Test
+    fun `execute should throw UnarchivedChildException when canArchive() returns false`() {
+        val administrationId = 1
+
+        given(canArchiveAdministration.execute(administrationId)).willReturn(false)
+
+        assertThatThrownBy {
+            ArchiveAdministration(administrationRepository, canArchiveAdministration).execute(administrationId)
+        }
+            .isInstanceOf(UnarchivedChildException::class.java)
+
+        verifyNoMoreInteractions(administrationRepository)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CanArchiveAdministrationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CanArchiveAdministrationUTests.kt
@@ -1,0 +1,76 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.administration
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.administration.AdministrationEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IAdministrationRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.administration.dtos.FullAdministrationDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class CanArchiveAdministrationUTests {
+    @MockBean
+    private lateinit var administrationRepository: IAdministrationRepository
+
+    @Test
+    fun `execute should return true when all control units are archived`() {
+        val administrationId = 1
+        val fullAdministration = FullAdministrationDTO(
+            administration = AdministrationEntity(
+                id = 1,
+                name = "Administration Name",
+                isArchived = false,
+            ),
+            controlUnits = listOf(
+                ControlUnitEntity(
+                    id = 0,
+                    administrationId = 1,
+                    areaNote = null,
+                    departmentAreaInseeCode = null,
+                    isArchived = true,
+                    name = "Control Unit Name",
+                    termsNote = null,
+                ),
+            ),
+        )
+
+        given(administrationRepository.findById(administrationId)).willReturn(fullAdministration)
+
+        val result = CanArchiveAdministration(administrationRepository).execute(administrationId)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `execute should return false when some control units are not archived`() {
+        val administrationId = 1
+        val fullAdministration = FullAdministrationDTO(
+            administration = AdministrationEntity(
+                id = 1,
+                name = "Administration Name",
+                isArchived = false,
+            ),
+            controlUnits = listOf(
+                ControlUnitEntity(
+                    id = 0,
+                    administrationId = 1,
+                    areaNote = null,
+                    departmentAreaInseeCode = null,
+                    isArchived = false,
+                    name = "Control Unit Name",
+                    termsNote = null,
+                ),
+            ),
+        )
+
+        given(administrationRepository.findById(administrationId)).willReturn(fullAdministration)
+
+        val result = CanArchiveAdministration(administrationRepository).execute(administrationId)
+
+        assertThat(result).isFalse
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CanDeleteAdministrationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CanDeleteAdministrationUTests.kt
@@ -1,0 +1,66 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.administration
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.administration.AdministrationEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IAdministrationRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.administration.dtos.FullAdministrationDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class CanDeleteAdministrationUTests {
+    @MockBean
+    private lateinit var administrationRepository: IAdministrationRepository
+
+    @Test
+    fun `execute should return true when control units are empty`() {
+        val administrationId = 1
+        val fullAdministration = FullAdministrationDTO(
+            administration = AdministrationEntity(
+                id = 1,
+                name = "Administration Name",
+                isArchived = false,
+            ),
+            controlUnits = listOf(),
+        )
+
+        given(administrationRepository.findById(administrationId)).willReturn(fullAdministration)
+
+        val result = CanDeleteAdministration(administrationRepository).execute(administrationId)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `execute should return false when control units are not empty`() {
+        val administrationId = 1
+        val fullAdministration = FullAdministrationDTO(
+            administration = AdministrationEntity(
+                id = 1,
+                name = "Administration Name",
+                isArchived = false,
+            ),
+            controlUnits = listOf(
+                ControlUnitEntity(
+                    id = 0,
+                    administrationId = 1,
+                    areaNote = null,
+                    departmentAreaInseeCode = null,
+                    isArchived = true,
+                    name = "Control Unit Name",
+                    termsNote = null,
+                ),
+            ),
+        )
+
+        given(administrationRepository.findById(administrationId)).willReturn(fullAdministration)
+
+        val result = CanDeleteAdministration(administrationRepository).execute(administrationId)
+
+        assertThat(result).isFalse
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CreateOrUpdateAdministrationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CreateOrUpdateAdministrationUTests.kt
@@ -1,11 +1,10 @@
-package fr.gouv.cacem.monitorenv.domain.use_cases
+package fr.gouv.cacem.monitorenv.domain.use_cases.administration
 
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import fr.gouv.cacem.monitorenv.domain.entities.administration.AdministrationEntity
 import fr.gouv.cacem.monitorenv.domain.repositories.IAdministrationRepository
-import fr.gouv.cacem.monitorenv.domain.use_cases.administration.CreateOrUpdateAdministration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CreateOrUpdateAdministrationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/CreateOrUpdateAdministrationUTests.kt
@@ -17,7 +17,7 @@ class CreateOrUpdateAdministrationUTests {
     private lateinit var administrationRepository: IAdministrationRepository
 
     @Test
-    fun `execute() should return save() result`() {
+    fun `execute should return save result`() {
         val newAdministration = AdministrationEntity(
             isArchived = false,
             name = "Administration Name",

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/DeleteAdministrationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/DeleteAdministrationUTests.kt
@@ -1,0 +1,43 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.administration
+
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cacem.monitorenv.domain.repositories.IAdministrationRepository
+import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.exceptions.ForeignKeyConstraintException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class DeleteAdministrationUTests {
+    @MockBean
+    private lateinit var administrationRepository: IAdministrationRepository
+
+    @MockBean
+    private lateinit var canDeleteAdministration: CanDeleteAdministration
+
+    @Test
+    fun `execute should delete when canDeleteAdministration returns true`() {
+        val administrationId = 1
+
+        given(canDeleteAdministration.execute(administrationId)).willReturn(true)
+
+        DeleteAdministration(administrationRepository, canDeleteAdministration).execute(administrationId)
+
+        verify(administrationRepository).deleteById(administrationId)
+    }
+
+    @Test
+    fun `execute should throw ForeignKeyConstraintException when canDeleteAdministration returns false`() {
+        val administrationId = 1
+
+        given(canDeleteAdministration.execute(administrationId)).willReturn(false)
+
+        assertThatThrownBy {
+            DeleteAdministration(administrationRepository, canDeleteAdministration).execute(administrationId)
+        }
+            .isInstanceOf(ForeignKeyConstraintException::class.java)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/GetAdministrationByIdUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/GetAdministrationByIdUTests.kt
@@ -1,0 +1,36 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.administration
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.administration.AdministrationEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IAdministrationRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.administration.dtos.FullAdministrationDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetAdministrationByIdUTests {
+    @MockBean
+    private lateinit var administrationRepository: IAdministrationRepository
+
+    @Test
+    fun `execute should return an administration by its ID`() {
+        val administrationId = 1
+        val fullAdministration = FullAdministrationDTO(
+            administration = AdministrationEntity(
+                id = 1,
+                name = "Administration Name",
+                isArchived = false,
+            ),
+            controlUnits = listOf(),
+        )
+
+        given(administrationRepository.findById(administrationId)).willReturn(fullAdministration)
+
+        val result = GetAdministrationById(administrationRepository).execute(administrationId)
+
+        assertThat(result).isEqualTo(fullAdministration)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/GetAdministrationsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/GetAdministrationsUTests.kt
@@ -1,0 +1,46 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.administration
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.administration.AdministrationEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IAdministrationRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.administration.dtos.FullAdministrationDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetAdministrationsUTests {
+    @MockBean
+    private lateinit var administrationRepository: IAdministrationRepository
+
+    @Test
+    fun `execute should return all administrations`() {
+        val fullAdministrations = listOf(
+            FullAdministrationDTO(
+                administration = AdministrationEntity(
+                    id = 1,
+                    name = "Administration Name",
+                    isArchived = false,
+                ),
+                controlUnits = listOf(),
+            ),
+            FullAdministrationDTO(
+                administration = AdministrationEntity(
+                    id = 2,
+                    name = "Administration Name 2",
+                    isArchived = false,
+                ),
+                controlUnits = listOf(),
+            ),
+        )
+
+        given(administrationRepository.findAll()).willReturn(fullAdministrations)
+
+        val result = GetAdministrations(administrationRepository).execute()
+
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result).isEqualTo(fullAdministrations)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/GetAdministrationsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/administration/GetAdministrationsUTests.kt
@@ -40,7 +40,7 @@ class GetAdministrationsUTests {
 
         val result = GetAdministrations(administrationRepository).execute()
 
-        assertThat(result.size).isEqualTo(1)
+        assertThat(result.size).isEqualTo(2)
         assertThat(result).isEqualTo(fullAdministrations)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/CanDeleteBaseUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/CanDeleteBaseUTests.kt
@@ -1,0 +1,71 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.base
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.base.BaseEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceType
+import fr.gouv.cacem.monitorenv.domain.repositories.IBaseRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.base.dtos.FullBaseDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class CanDeleteBaseUTests {
+    @MockBean
+    private lateinit var baseRepository: IBaseRepository
+
+    @Test
+    fun `execute should return true when control unit resources are empty`() {
+        val baseId = 1
+        val fullBase = FullBaseDTO(
+            base = BaseEntity(
+                id = 1,
+                latitude = 0.0,
+                longitude = 0.0,
+                name = "Base Name",
+            ),
+            controlUnitResources = listOf(),
+        )
+
+        given(baseRepository.findById(baseId)).willReturn(fullBase)
+
+        val result = CanDeleteBase(baseRepository).execute(baseId)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `execute should return false when control unit resources are not empty`() {
+        val baseId = 1
+        val fullBase = FullBaseDTO(
+            base = BaseEntity(
+                id = 1,
+                latitude = 0.0,
+                longitude = 0.0,
+                name = "Base Name",
+            ),
+            controlUnitResources = listOf(
+                ControlUnitResourceEntity(
+                    id = 0,
+                    baseId = 1,
+                    controlUnitId = 0,
+                    isArchived = false,
+                    name = "Control Unit Resource Name",
+                    note = null,
+                    photo = null,
+                    type = ControlUnitResourceType.BARGE,
+
+                ),
+            ),
+        )
+
+        given(baseRepository.findById(baseId)).willReturn(fullBase)
+
+        val result = CanDeleteBase(baseRepository).execute(baseId)
+
+        assertThat(result).isFalse
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/CreateOrUpdateBaseUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/CreateOrUpdateBaseUTests.kt
@@ -17,7 +17,7 @@ class CreateOrUpdateBaseUTests {
     private lateinit var baseRepository: IBaseRepository
 
     @Test
-    fun `execute() should return save() result`() {
+    fun `execute should return save() result`() {
         val newBase = BaseEntity(
             latitude = 0.0,
             longitude = 0.0,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/CreateOrUpdateBaseUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/CreateOrUpdateBaseUTests.kt
@@ -1,11 +1,10 @@
-package fr.gouv.cacem.monitorenv.domain.use_cases
+package fr.gouv.cacem.monitorenv.domain.use_cases.base
 
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import fr.gouv.cacem.monitorenv.domain.entities.base.BaseEntity
 import fr.gouv.cacem.monitorenv.domain.repositories.IBaseRepository
-import fr.gouv.cacem.monitorenv.domain.use_cases.base.CreateOrUpdateBase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/DeleteBaseUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/DeleteBaseUTests.kt
@@ -1,0 +1,43 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.base
+
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cacem.monitorenv.domain.repositories.IBaseRepository
+import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.exceptions.ForeignKeyConstraintException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class DeleteBaseUTests {
+    @MockBean
+    private lateinit var baseRepository: IBaseRepository
+
+    @MockBean
+    private lateinit var canDeleteBase: CanDeleteBase
+
+    @Test
+    fun `execute should delete when canDeleteBase returns true`() {
+        val baseId = 1
+
+        given(canDeleteBase.execute(baseId)).willReturn(true)
+
+        DeleteBase(baseRepository, canDeleteBase).execute(baseId)
+
+        verify(baseRepository).deleteById(baseId)
+    }
+
+    @Test
+    fun `execute should throw ForeignKeyConstraintException when canDeleteBase returns false`() {
+        val baseId = 1
+
+        given(canDeleteBase.execute(baseId)).willReturn(false)
+
+        assertThatThrownBy {
+            DeleteBase(baseRepository, canDeleteBase).execute(baseId)
+        }
+            .isInstanceOf(ForeignKeyConstraintException::class.java)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/GetBaseByIdUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/GetBaseByIdUTests.kt
@@ -1,0 +1,37 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.base
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.base.BaseEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IBaseRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.base.dtos.FullBaseDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetBaseByIdUTests {
+    @MockBean
+    private lateinit var baseRepository: IBaseRepository
+
+    @Test
+    fun `execute should return a base by its ID`() {
+        val baseId = 1
+        val fullBase = FullBaseDTO(
+            base = BaseEntity(
+                id = 1,
+                latitude = 0.0,
+                longitude = 0.0,
+                name = "Base Name",
+            ),
+            controlUnitResources = listOf(),
+        )
+
+        given(baseRepository.findById(baseId)).willReturn(fullBase)
+
+        val result = GetBaseById(baseRepository).execute(baseId)
+
+        assertThat(result).isEqualTo(fullBase)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/GetBasesUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/GetBasesUTests.kt
@@ -42,7 +42,7 @@ class GetBasesUTests {
 
         val result = GetBases(baseRepository).execute()
 
-        assertThat(result.size).isEqualTo(1)
+        assertThat(result.size).isEqualTo(2)
         assertThat(result).isEqualTo(bases)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/GetBasesUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/base/GetBasesUTests.kt
@@ -1,0 +1,48 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.base
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.base.BaseEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IBaseRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.base.dtos.FullBaseDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetBasesUTests {
+    @MockBean
+    private lateinit var baseRepository: IBaseRepository
+
+    @Test
+    fun `execute should return all bases`() {
+        val bases = listOf(
+            FullBaseDTO(
+                base = BaseEntity(
+                    id = 1,
+                    latitude = 0.0,
+                    longitude = 0.0,
+                    name = "Base Name",
+                ),
+                controlUnitResources = listOf(),
+            ),
+            FullBaseDTO(
+                base = BaseEntity(
+                    id = 2,
+                    latitude = 0.0,
+                    longitude = 0.0,
+                    name = "Base Name 2",
+                ),
+                controlUnitResources = listOf(),
+            ),
+        )
+
+        given(baseRepository.findAll()).willReturn(bases)
+
+        val result = GetBases(baseRepository).execute()
+
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result).isEqualTo(bases)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/ArchiveControlUnitResourceUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/ArchiveControlUnitResourceUTests.kt
@@ -1,0 +1,23 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitResourceRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class ArchiveControlUnitResourceUTests {
+    @MockBean
+    private lateinit var controlUnitResourceRepository: IControlUnitResourceRepository
+
+    @Test
+    fun `execute should archive a control unit resource by its ID`() {
+        val controlUnitResourceId = 1
+
+        ArchiveControlUnitResource(controlUnitResourceRepository).execute(controlUnitResourceId)
+
+        verify(controlUnitResourceRepository).archiveById(controlUnitResourceId)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/ArchiveControlUnitUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/ArchiveControlUnitUTests.kt
@@ -1,0 +1,23 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class ArchiveControlUnitUTests {
+    @MockBean
+    private lateinit var controlUnitRepository: IControlUnitRepository
+
+    @Test
+    fun `execute should archive a control unit by its ID`() {
+        val controlUnitId = 1
+
+        ArchiveControlUnit(controlUnitRepository).execute(controlUnitId)
+
+        verify(controlUnitRepository).archiveById(controlUnitId)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResourceUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResourceUTests.kt
@@ -1,0 +1,64 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionSourceEnum
+import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.ZonedDateTime
+
+@ExtendWith(SpringExtension::class)
+class CanDeleteControlUnitResourceUTests {
+    @MockBean
+    private lateinit var missionRepository: IMissionRepository
+
+    @Test
+    fun `execute should return true when missions are empty`() {
+        val controlUnitResourceId = 1
+
+        given(missionRepository.findByControlUnitId(controlUnitResourceId)).willReturn(listOf())
+
+        val result = CanDeleteControlUnitResource(missionRepository).execute(controlUnitResourceId)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `execute should return false when missions are not empty`() {
+        val controlUnitResourceId = 1
+
+        given(missionRepository.findByControlUnitId(controlUnitResourceId)).willReturn(
+            listOf(
+                MissionEntity(
+                    id = 1,
+                    missionTypes = listOf(),
+                    controlUnits = listOf(),
+                    openBy = null,
+                    closedBy = null,
+                    observationsCacem = null,
+                    observationsCnsp = null,
+                    facade = null,
+                    geom = null,
+                    startDateTimeUtc = ZonedDateTime.now(),
+                    endDateTimeUtc = null,
+                    envActions = listOf(),
+                    isClosed = false,
+                    isDeleted = false,
+                    isGeometryComputedFromControls = false,
+                    missionSource = MissionSourceEnum.MONITORENV,
+                    hasMissionOrder = false,
+                    isUnderJdp = false,
+
+                ),
+            ),
+        )
+
+        val result = CanDeleteControlUnitResource(missionRepository).execute(controlUnitResourceId)
+
+        assertThat(result).isFalse
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResourceUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitResourceUTests.kt
@@ -20,7 +20,7 @@ class CanDeleteControlUnitResourceUTests {
     fun `execute should return true when missions are empty`() {
         val controlUnitResourceId = 1
 
-        given(missionRepository.findByControlUnitId(controlUnitResourceId)).willReturn(listOf())
+        given(missionRepository.findByControlUnitResourceId(controlUnitResourceId)).willReturn(listOf())
 
         val result = CanDeleteControlUnitResource(missionRepository).execute(controlUnitResourceId)
 
@@ -31,7 +31,7 @@ class CanDeleteControlUnitResourceUTests {
     fun `execute should return false when missions are not empty`() {
         val controlUnitResourceId = 1
 
-        given(missionRepository.findByControlUnitId(controlUnitResourceId)).willReturn(
+        given(missionRepository.findByControlUnitResourceId(controlUnitResourceId)).willReturn(
             listOf(
                 MissionEntity(
                     id = 1,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CanDeleteControlUnitUTests.kt
@@ -1,0 +1,116 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionSourceEnum
+import fr.gouv.cacem.monitorenv.domain.entities.reporting.ReportingEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
+import fr.gouv.cacem.monitorenv.domain.repositories.IReportingRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.ZonedDateTime
+
+@ExtendWith(SpringExtension::class)
+class CanDeleteControlUnitUTests {
+    @MockBean
+    private lateinit var missionRepository: IMissionRepository
+
+    @MockBean
+    private lateinit var reportingRepository: IReportingRepository
+
+    @Test
+    fun `execute should return true when both missions and reportings are empty`() {
+        val controlUnitId = 1
+
+        given(missionRepository.findByControlUnitId(controlUnitId)).willReturn(listOf())
+        given(reportingRepository.findByControlUnitId(controlUnitId)).willReturn(listOf())
+
+        val result = CanDeleteControlUnit(missionRepository, reportingRepository).execute(controlUnitId)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `execute should return false when missions are not empty`() {
+        val controlUnitId = 1
+
+        given(missionRepository.findByControlUnitId(controlUnitId)).willReturn(
+            listOf(
+                MissionEntity(
+                    id = 1,
+                    missionTypes = listOf(),
+                    controlUnits = listOf(),
+                    openBy = null,
+                    closedBy = null,
+                    observationsCacem = null,
+                    observationsCnsp = null,
+                    facade = null,
+                    geom = null,
+                    startDateTimeUtc = ZonedDateTime.now(),
+                    endDateTimeUtc = null,
+                    envActions = listOf(),
+                    isClosed = false,
+                    isDeleted = false,
+                    isGeometryComputedFromControls = false,
+                    missionSource = MissionSourceEnum.MONITORENV,
+                    hasMissionOrder = false,
+                    isUnderJdp = false,
+
+                ),
+            ),
+        )
+        given(reportingRepository.findByControlUnitId(controlUnitId)).willReturn(listOf())
+
+        val result = CanDeleteControlUnit(missionRepository, reportingRepository).execute(controlUnitId)
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `execute should return false when reportings are not empty`() {
+        val controlUnitId = 1
+
+        given(missionRepository.findByControlUnitId(controlUnitId)).willReturn(listOf())
+        given(reportingRepository.findByControlUnitId(controlUnitId)).willReturn(
+            listOf(
+                ReportingEntity(
+                    id = 1,
+                    reportingId = null,
+                    sourceType = null,
+                    semaphoreId = null,
+                    controlUnitId = null,
+                    sourceName = null,
+                    targetType = null,
+                    vehicleType = null,
+                    targetDetails = null,
+                    geom = null,
+                    seaFront = null,
+                    description = null,
+                    reportType = null,
+                    theme = null,
+                    subThemes = null,
+                    actionTaken = null,
+                    isControlRequired = null,
+                    hasNoUnitAvailable = null,
+                    createdAt = ZonedDateTime.now(),
+                    validityTime = null,
+                    isArchived = false,
+                    isDeleted = false,
+                    openBy = null,
+                    missionId = null,
+                    attachedToMissionAtUtc = null,
+                    detachedFromMissionAtUtc = null,
+                    attachedEnvActionId = null,
+
+                ),
+            ),
+        )
+
+        val result = CanDeleteControlUnit(missionRepository, reportingRepository).execute(controlUnitId)
+
+        assertThat(result).isFalse
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitContactUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitContactUTests.kt
@@ -1,11 +1,10 @@
-package fr.gouv.cacem.monitorenv.domain.use_cases
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
 
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitContactEntity
 import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitContactRepository
-import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.CreateOrUpdateControlUnitContact
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitContactUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitContactUTests.kt
@@ -17,7 +17,7 @@ class CreateOrUpdateControlUnitContactUTests {
     private lateinit var controlUnitContactRepository: IControlUnitContactRepository
 
     @Test
-    fun `execute() should return save() result`() {
+    fun `execute should return save() result`() {
         val newControlUnitContact = ControlUnitContactEntity(
             controlUnitId = 2,
             email = null,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitResourceUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitResourceUTests.kt
@@ -1,4 +1,4 @@
-package fr.gouv.cacem.monitorenv.domain.use_cases
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
 
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.times
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.verify
 import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceEntity
 import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceType
 import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitResourceRepository
-import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.CreateOrUpdateControlUnitResource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitResourceUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitResourceUTests.kt
@@ -18,7 +18,7 @@ class CreateOrUpdateControlUnitResourceUTests {
     private lateinit var controlUnitResourceRepository: IControlUnitResourceRepository
 
     @Test
-    fun `execute() should return save() result`() {
+    fun `execute should return save() result`() {
         val newControlUnitResource = ControlUnitResourceEntity(
             baseId = 2,
             controlUnitId = 3,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitUTests.kt
@@ -1,11 +1,10 @@
-package fr.gouv.cacem.monitorenv.domain.use_cases
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
 
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
 import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitRepository
-import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.CreateOrUpdateControlUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/CreateOrUpdateControlUnitUTests.kt
@@ -17,7 +17,7 @@ class CreateOrUpdateControlUnitUTests {
     private lateinit var controlUnitRepository: IControlUnitRepository
 
     @Test
-    fun `execute() should return save() result`() {
+    fun `execute should return save() result`() {
         val newControlUnit = ControlUnitEntity(
             administrationId = 2,
             areaNote = null,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitContactUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitContactUTests.kt
@@ -1,0 +1,23 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitContactRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class DeleteControlUnitContactUTests {
+    @MockBean
+    private lateinit var controlUnitContactRepository: IControlUnitContactRepository
+
+    @Test
+    fun `execute should delete control unit contact by its ID`() {
+        val controlUnitContactId = 1
+
+        DeleteControlUnitContact(controlUnitContactRepository).execute(controlUnitContactId)
+
+        verify(controlUnitContactRepository).deleteById(controlUnitContactId)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitResourceUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitResourceUTests.kt
@@ -1,0 +1,47 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitResourceRepository
+import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.exceptions.ForeignKeyConstraintException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class DeleteControlUnitResourceUTests {
+    @MockBean
+    private lateinit var controlUnitResourceRepository: IControlUnitResourceRepository
+
+    @MockBean
+    private lateinit var canDeleteControlUnitResource: CanDeleteControlUnitResource
+
+    @Test
+    fun `execute should delete control unit resource when canDeleteControlUnitResource returns true`() {
+        val controlUnitResourceId = 1
+
+        given(canDeleteControlUnitResource.execute(controlUnitResourceId)).willReturn(true)
+
+        DeleteControlUnitResource(canDeleteControlUnitResource, controlUnitResourceRepository).execute(
+            controlUnitResourceId,
+        )
+
+        verify(controlUnitResourceRepository).deleteById(controlUnitResourceId)
+    }
+
+    @Test
+    fun `execute should throw ForeignKeyConstraintException when canDeleteControlUnitResource returns false`() {
+        val controlUnitResourceId = 1
+
+        given(canDeleteControlUnitResource.execute(controlUnitResourceId)).willReturn(false)
+
+        assertThatThrownBy {
+            DeleteControlUnitResource(canDeleteControlUnitResource, controlUnitResourceRepository).execute(
+                controlUnitResourceId,
+            )
+        }
+            .isInstanceOf(ForeignKeyConstraintException::class.java)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/DeleteControlUnitUTests.kt
@@ -1,0 +1,43 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitRepository
+import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.exceptions.ForeignKeyConstraintException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class DeleteControlUnitUTests {
+    @MockBean
+    private lateinit var controlUnitRepository: IControlUnitRepository
+
+    @MockBean
+    private lateinit var canDeleteControlUnit: CanDeleteControlUnit
+
+    @Test
+    fun `execute should delete control unit when canDeleteControlUnit returns true`() {
+        val controlUnitId = 1
+
+        given(canDeleteControlUnit.execute(controlUnitId)).willReturn(true)
+
+        DeleteControlUnit(controlUnitRepository, canDeleteControlUnit).execute(controlUnitId)
+
+        verify(controlUnitRepository).deleteById(controlUnitId)
+    }
+
+    @Test
+    fun `execute should throw ForeignKeyConstraintException when canDeleteControlUnit returns false`() {
+        val controlUnitId = 1
+
+        given(canDeleteControlUnit.execute(controlUnitId)).willReturn(false)
+
+        assertThatThrownBy {
+            DeleteControlUnit(controlUnitRepository, canDeleteControlUnit).execute(controlUnitId)
+        }
+            .isInstanceOf(ForeignKeyConstraintException::class.java)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitByIdUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitByIdUTests.kt
@@ -1,0 +1,48 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.administration.AdministrationEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.dtos.FullControlUnitDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetControlUnitByIdUTests {
+    @MockBean
+    private lateinit var controlUnitRepository: IControlUnitRepository
+
+    @Test
+    fun `execute should return a control unit by its ID`() {
+        val controlUnitId = 1
+        val fullControlUnit = FullControlUnitDTO(
+            administration = AdministrationEntity(
+                id = 0,
+                name = "Administration Name",
+                isArchived = false,
+            ),
+            controlUnit = ControlUnitEntity(
+                id = 1,
+                administrationId = 0,
+                areaNote = null,
+                departmentAreaInseeCode = null,
+                isArchived = false,
+                name = "Control Unit Name",
+                termsNote = null,
+            ),
+            departmentArea = null,
+            controlUnitContacts = listOf(),
+            controlUnitResources = listOf(),
+        )
+
+        given(controlUnitRepository.findById(controlUnitId)).willReturn(fullControlUnit)
+
+        val result = GetControlUnitById(controlUnitRepository).execute(controlUnitId)
+
+        assertThat(result).isEqualTo(fullControlUnit)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitContactByIdUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitContactByIdUTests.kt
@@ -1,0 +1,47 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitContactEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitContactRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.dtos.FullControlUnitContactDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetControlUnitContactByIdUTests {
+    @MockBean
+    private lateinit var controlUnitContactRepository: IControlUnitContactRepository
+
+    @Test
+    fun `execute should return a control unit contact by its ID`() {
+        val controlUnitContactId = 1
+        val fullControlUnitContact = FullControlUnitContactDTO(
+            controlUnit = ControlUnitEntity(
+                id = 0,
+                administrationId = 0,
+                areaNote = null,
+                departmentAreaInseeCode = null,
+                isArchived = false,
+                name = "Control Unit Name",
+                termsNote = null,
+            ),
+            controlUnitContact = ControlUnitContactEntity(
+                id = 1,
+                controlUnitId = 0,
+                email = null,
+                name = "Control Unit Contact Name",
+                phone = null,
+            ),
+        )
+
+        given(controlUnitContactRepository.findById(controlUnitContactId)).willReturn(fullControlUnitContact)
+
+        val result = GetControlUnitContactById(controlUnitContactRepository).execute(controlUnitContactId)
+
+        assertThat(result).isEqualTo(fullControlUnitContact)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitContactsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitContactsUTests.kt
@@ -1,0 +1,68 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitContactEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitContactRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.dtos.FullControlUnitContactDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetControlUnitContactsUTests {
+
+    @MockBean
+    private lateinit var controlUnitContactRepository: IControlUnitContactRepository
+
+    @Test
+    fun `execute should return all control unit contacts`() {
+        val controlUnitContacts = listOf(
+            FullControlUnitContactDTO(
+                controlUnit = ControlUnitEntity(
+                    id = 1,
+                    administrationId = 101,
+                    areaNote = "Area 1",
+                    departmentAreaInseeCode = "A1",
+                    isArchived = false,
+                    name = "Control Unit 1",
+                    termsNote = "Terms 1",
+                ),
+                controlUnitContact = ControlUnitContactEntity(
+                    id = 1,
+                    controlUnitId = 1,
+                    email = "contact1@example.com",
+                    name = "Contact 1",
+                    phone = "123-456-7890",
+                ),
+            ),
+            FullControlUnitContactDTO(
+                controlUnit = ControlUnitEntity(
+                    id = 2,
+                    administrationId = 102,
+                    areaNote = "Area 2",
+                    departmentAreaInseeCode = "A2",
+                    isArchived = false,
+                    name = "Control Unit 2",
+                    termsNote = "Terms 2",
+                ),
+                controlUnitContact = ControlUnitContactEntity(
+                    id = 2,
+                    controlUnitId = 2,
+                    email = "contact2@example.com",
+                    name = "Contact 2",
+                    phone = "098-765-4321",
+                ),
+            ),
+        )
+
+        given(controlUnitContactRepository.findAll()).willReturn(controlUnitContacts)
+
+        val result = GetControlUnitContacts(controlUnitContactRepository).execute()
+
+        assertThat(result).isEqualTo(controlUnitContacts)
+        assertThat(result.size).isEqualTo(2)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitResourceByIdUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitResourceByIdUTests.kt
@@ -1,0 +1,58 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.base.BaseEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceType
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitResourceRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.dtos.FullControlUnitResourceDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetControlUnitResourceByIdUTests {
+    @MockBean
+    private lateinit var controlUnitResourceRepository: IControlUnitResourceRepository
+
+    @Test
+    fun `execute should return a control unit resource by its ID`() {
+        val controlUnitResourceId = 1
+        val fullControlUnitResource = FullControlUnitResourceDTO(
+            base = BaseEntity(
+                id = 0,
+                latitude = 0.0,
+                longitude = 0.0,
+                name = "Base Name",
+            ),
+            controlUnit = ControlUnitEntity(
+                id = 0,
+                administrationId = 0,
+                areaNote = null,
+                departmentAreaInseeCode = null,
+                isArchived = false,
+                name = "Control Unit Name",
+                termsNote = null,
+            ),
+            controlUnitResource = ControlUnitResourceEntity(
+                id = 1,
+                baseId = 0,
+                controlUnitId = 0,
+                isArchived = false,
+                name = "Control Unit Resource Name",
+                note = null,
+                photo = null,
+                type = ControlUnitResourceType.BARGE,
+            ),
+        )
+
+        given(controlUnitResourceRepository.findById(controlUnitResourceId)).willReturn(fullControlUnitResource)
+
+        val result = GetControlUnitResourceById(controlUnitResourceRepository).execute(controlUnitResourceId)
+
+        assertThat(result).isEqualTo(fullControlUnitResource)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitResourcesUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitResourcesUTests.kt
@@ -1,0 +1,88 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.base.BaseEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitResourceType
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitResourceRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.dtos.FullControlUnitResourceDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetControlUnitResourcesUTests {
+
+    @MockBean
+    private lateinit var controlUnitResourceRepository: IControlUnitResourceRepository
+
+    @Test
+    fun `execute should return all control unit resources`() {
+        val controlUnitResources = listOf(
+            FullControlUnitResourceDTO(
+                base = BaseEntity(
+                    id = 1,
+                    latitude = 40.7128,
+                    longitude = -74.0060,
+                    name = "Base 1",
+                ),
+                controlUnit = ControlUnitEntity(
+                    id = 1,
+                    administrationId = 101,
+                    areaNote = "Area 1",
+                    departmentAreaInseeCode = "A1",
+                    isArchived = false,
+                    name = "Control Unit 1",
+                    termsNote = "Terms 1",
+                ),
+                controlUnitResource = ControlUnitResourceEntity(
+                    id = 1,
+                    baseId = 1,
+                    controlUnitId = 1,
+                    isArchived = false,
+                    name = "Resource 1",
+                    note = "Note 1",
+                    photo = null,
+                    type = ControlUnitResourceType.BARGE,
+                ),
+            ),
+            FullControlUnitResourceDTO(
+                base = BaseEntity(
+                    id = 2,
+                    latitude = 34.0522,
+                    longitude = -118.2437,
+                    name = "Base 2",
+                ),
+                controlUnit = ControlUnitEntity(
+                    id = 2,
+                    administrationId = 102,
+                    areaNote = "Area 2",
+                    departmentAreaInseeCode = "A2",
+                    isArchived = false,
+                    name = "Control Unit 2",
+                    termsNote = "Terms 2",
+                ),
+                controlUnitResource = ControlUnitResourceEntity(
+                    id = 2,
+                    baseId = 2,
+                    controlUnitId = 2,
+                    isArchived = false,
+                    name = "Resource 2",
+                    note = "Note 2",
+                    photo = null,
+                    type = ControlUnitResourceType.BARGE,
+                ),
+            ),
+        )
+
+        given(controlUnitResourceRepository.findAll()).willReturn(controlUnitResources)
+
+        val result = GetControlUnitResources(controlUnitResourceRepository).execute()
+
+        assertThat(result).isEqualTo(controlUnitResources)
+        assertThat(result.size).isEqualTo(2)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/controlUnit/GetControlUnitsUTests.kt
@@ -1,0 +1,70 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.administration.AdministrationEntity
+import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.ControlUnitEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitRepository
+import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.dtos.FullControlUnitDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetControlUnitsUTests {
+
+    @MockBean
+    private lateinit var controlUnitRepository: IControlUnitRepository
+
+    @Test
+    fun `execute should return all control units`() {
+        val fullControlUnits = listOf(
+            FullControlUnitDTO(
+                administration = AdministrationEntity(
+                    id = 0,
+                    name = "Admin 1",
+                    isArchived = false,
+                ),
+                controlUnit = ControlUnitEntity(
+                    id = 1,
+                    administrationId = 0,
+                    areaNote = "Area 1",
+                    departmentAreaInseeCode = "A1",
+                    isArchived = false,
+                    name = "CU 1",
+                    termsNote = "Terms 1",
+                ),
+                departmentArea = null,
+                controlUnitContacts = listOf(),
+                controlUnitResources = listOf(),
+            ),
+            FullControlUnitDTO(
+                administration = AdministrationEntity(
+                    id = 1,
+                    name = "Admin 2",
+                    isArchived = false,
+                ),
+                controlUnit = ControlUnitEntity(
+                    id = 2,
+                    administrationId = 1,
+                    areaNote = "Area 2",
+                    departmentAreaInseeCode = "A2",
+                    isArchived = false,
+                    name = "CU 2",
+                    termsNote = "Terms 2",
+                ),
+                departmentArea = null,
+                controlUnitContacts = listOf(),
+                controlUnitResources = listOf(),
+            ),
+        )
+
+        given(controlUnitRepository.findAll()).willReturn(fullControlUnits)
+
+        val result = GetControlUnits(controlUnitRepository).execute()
+
+        assertThat(result).isEqualTo(fullControlUnits)
+        assertThat(result.size).isEqualTo(2)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/departmentArea/GetDepartmentAreaByInseeCodeUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/departmentArea/GetDepartmentAreaByInseeCodeUTests.kt
@@ -1,0 +1,32 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.departmentArea
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.departmentArea.DepartmentAreaEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IDepartmentAreaRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetDepartmentAreaByInseeCodeUTests {
+    @MockBean
+    private lateinit var departmentAreaRepository: IDepartmentAreaRepository
+
+    @Test
+    fun `execute should return a department area by its INSEE Code`() {
+        val departmentAreaId = "1"
+        val departmentArea = DepartmentAreaEntity(
+            inseeCode = "1",
+            geometry = null,
+            name = "Department Area Name",
+        )
+
+        given(departmentAreaRepository.findByInseeCode(departmentAreaId)).willReturn(departmentArea)
+
+        val result = GetDepartmentAreaByInseeCode(departmentAreaRepository).execute(departmentAreaId)
+
+        assertThat(result).isEqualTo(departmentArea)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/departmentArea/GetDepartmentAreasUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/departmentArea/GetDepartmentAreasUTests.kt
@@ -1,0 +1,39 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.departmentArea
+
+import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cacem.monitorenv.domain.entities.departmentArea.DepartmentAreaEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IDepartmentAreaRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetDepartmentAreasUTests {
+    @MockBean
+    private lateinit var departmentAreaRepository: IDepartmentAreaRepository
+
+    @Test
+    fun `execute should return all department areas`() {
+        val departmentAreas = listOf(
+            DepartmentAreaEntity(
+                inseeCode = "1",
+                geometry = null,
+                name = "DepartmentArea Name",
+            ),
+            DepartmentAreaEntity(
+                inseeCode = "2",
+                geometry = null,
+                name = "DepartmentArea Name 2",
+            ),
+        )
+
+        given(departmentAreaRepository.findAll()).willReturn(departmentAreas)
+
+        val result = GetDepartmentAreas(departmentAreaRepository).execute()
+
+        assertThat(result.size).isEqualTo(2)
+        assertThat(result).isEqualTo(departmentAreas)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiControlUnitResourcesControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiControlUnitResourcesControllerITests.kt
@@ -36,6 +36,9 @@ class ApiControlUnitResourcesControllerITests {
     private lateinit var archiveControlUnitResource: ArchiveControlUnitResource
 
     @MockBean
+    private lateinit var canDeleteControlUnitResource: CanDeleteControlUnitResource
+
+    @MockBean
     private lateinit var createOrUpdateControlUnitResource: CreateOrUpdateControlUnitResource
 
     @MockBean
@@ -51,7 +54,7 @@ class ApiControlUnitResourcesControllerITests {
     private lateinit var objectMapper: ObjectMapper
 
     @Test
-    fun `archive() should archive a control unit resource`() {
+    fun `archive should archive a control unit resource`() {
         val controlUnitResourceId = 1
 
         mockMvc.perform(
@@ -63,7 +66,20 @@ class ApiControlUnitResourcesControllerITests {
     }
 
     @Test
-    fun `create() should create a resource`() {
+    fun `canDelete should check if a control unit resource can be deleted`() {
+        val controlUnitResourceId = 1
+
+        given(canDeleteControlUnitResource.execute(controlUnitResourceId)).willReturn(true)
+
+        mockMvc.perform(get("/api/v1/control_unit_resources/$controlUnitResourceId/can_delete"))
+            .andExpect(status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.value").value(true))
+
+        BDDMockito.verify(canDeleteControlUnitResource).execute(controlUnitResourceId)
+    }
+
+    @Test
+    fun `create should create a control unit resource`() {
         val expectedCreatedControlUnitResource = ControlUnitResourceEntity(
             id = 1,
             baseId = 0,
@@ -100,7 +116,7 @@ class ApiControlUnitResourcesControllerITests {
     }
 
     @Test
-    fun `delete() should delete a control unit resource`() {
+    fun `delete should delete a control unit resource`() {
         val controlUnitResourceId = 1
 
         mockMvc.perform(
@@ -112,7 +128,7 @@ class ApiControlUnitResourcesControllerITests {
     }
 
     @Test
-    fun `get() should get a control unit resource by its ID`() {
+    fun `get should get a control unit resource by its ID`() {
         val expectedFullControlUnitResource = FullControlUnitResourceDTO(
             base = BaseEntity(
                 id = 0,
@@ -152,7 +168,7 @@ class ApiControlUnitResourcesControllerITests {
     }
 
     @Test
-    fun `getAll() should get all control unit resources`() {
+    fun `getAll should get all control unit resources`() {
         val expectedFullControlUnitResources = listOf(
             FullControlUnitResourceDTO(
                 base = BaseEntity(
@@ -221,7 +237,7 @@ class ApiControlUnitResourcesControllerITests {
     }
 
     @Test
-    fun `update() should update a control unit resource`() {
+    fun `update should update a control unit resource`() {
         val expectedUpdatedControlUnitResource = ControlUnitResourceEntity(
             id = 1,
             baseId = 0,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaMissionRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaMissionRepositoryITests.kt
@@ -33,10 +33,18 @@ class JpaMissionRepositoryITests : AbstractDBTests() {
 
     @Test
     @Transactional
-    fun `findByControlUnitId() should find the matching missions`() {
+    fun `findByControlUnitId should find the matching missions`() {
         val foundMissions = jpaMissionRepository.findByControlUnitId(10002)
 
         assertThat(foundMissions).hasSize(18)
+    }
+
+    @Test
+    @Transactional
+    fun `findByControlUnitResourceId should find the matching missions`() {
+        val foundMissions = jpaMissionRepository.findByControlUnitResourceId(8)
+
+        assertThat(foundMissions).hasSize(3)
     }
 
     @Test

--- a/frontend/cypress/e2e/back_office/administration_table/row_actions.spec.ts
+++ b/frontend/cypress/e2e/back_office/administration_table/row_actions.spec.ts
@@ -8,18 +8,14 @@ context('Back Office > Administration Table > Row Actions', () => {
     cy.wait('@getAdministrations')
   })
 
-  it('Should show a dialog when trying to archive an administration linked to unarchived control units', () => {
-    cy.intercept('POST', `/api/v1/administrations/1005/archive`).as('archiveAdministration')
-
+  it('Should show an error dialog when trying to archive an administration linked to unarchived control units', () => {
     cy.getTableRowById(1005).clickButton('Archiver cette administration')
 
     cy.get('.Component-Dialog').should('be.visible')
     cy.contains('Archivage impossible').should('be.visible')
   })
 
-  it('Should show a dialog when trying to delete an administration linked to some control units', () => {
-    cy.intercept('DELETE', `/api/v1/administrations/1005`).as('deleteAdministration')
-
+  it('Should show an error dialog when trying to delete an administration linked to some control units', () => {
     cy.getTableRowById(1005).clickButton('Supprimer cette administration')
 
     cy.get('.Component-Dialog').should('be.visible')

--- a/frontend/cypress/e2e/back_office/base_table/row_actions.spec.ts
+++ b/frontend/cypress/e2e/back_office/base_table/row_actions.spec.ts
@@ -8,9 +8,7 @@ context('Back Office > Base Table > Row Actions', () => {
     cy.wait('@getBases')
   })
 
-  it('Should show a dialog when trying to delete a base linked to some control unit resources', () => {
-    cy.intercept('DELETE', `/api/v1/bases/3`).as('deleteBase')
-
+  it('Should show an error dialog when trying to delete a base linked to some control unit resources', () => {
     cy.getTableRowById(3).clickButton('Supprimer cette base')
 
     cy.get('.Component-Dialog').should('be.visible')

--- a/frontend/cypress/e2e/back_office/control_unit_table/row_actions.spec.ts
+++ b/frontend/cypress/e2e/back_office/control_unit_table/row_actions.spec.ts
@@ -8,9 +8,7 @@ context('Back Office > Control Unit Table > Row Actions', () => {
     cy.wait('@getControlUnits')
   })
 
-  it('Should show a dialog when trying to delete a control unit linked to some missions or reportings', () => {
-    cy.intercept('DELETE', `/api/v2/control_units/10000`).as('deleteControlUnit')
-
+  it('Should show an error dialog when trying to delete a control unit linked to some missions or reportings', () => {
     cy.getTableRowById(10000).clickButton('Supprimer cette unité de contrôle')
 
     cy.get('.Component-Dialog').should('be.visible')

--- a/frontend/cypress/e2e/main_window/control_unit_dialog/contact_list.spec.ts
+++ b/frontend/cypress/e2e/main_window/control_unit_dialog/contact_list.spec.ts
@@ -1,8 +1,8 @@
-import { gotToMainWindowAndOpenControlUnit } from './utils'
+import { goToMainWindowAndOpenControlUnit } from './utils'
 
 context('Main Window > Control Unit Dialog > Contact List', () => {
   beforeEach(() => {
-    gotToMainWindowAndOpenControlUnit(10000)
+    goToMainWindowAndOpenControlUnit(10000)
   })
 
   it('Should show all contacts by default', () => {

--- a/frontend/cypress/e2e/main_window/control_unit_dialog/form.spec.ts
+++ b/frontend/cypress/e2e/main_window/control_unit_dialog/form.spec.ts
@@ -1,8 +1,8 @@
-import { gotToMainWindowAndOpenControlUnit } from './utils'
+import { goToMainWindowAndOpenControlUnit } from './utils'
 
 context('Main Window > Control Unit Dialog > Resource List', () => {
   beforeEach(() => {
-    gotToMainWindowAndOpenControlUnit(10000)
+    goToMainWindowAndOpenControlUnit(10000)
   })
 
   it('Should edit a control unit', () => {

--- a/frontend/cypress/e2e/main_window/control_unit_dialog/resource_list.spec.ts
+++ b/frontend/cypress/e2e/main_window/control_unit_dialog/resource_list.spec.ts
@@ -1,18 +1,18 @@
 import { faker } from '@faker-js/faker'
 
-import { gotToMainWindowAndOpenControlUnit } from './utils'
+import { goToMainWindowAndOpenControlUnit } from './utils'
 
 context('Main Window > Control Unit Dialog > Resource List', () => {
-  beforeEach(() => {
-    gotToMainWindowAndOpenControlUnit(10000)
-  })
-
   it('Should show all resources by default', () => {
+    goToMainWindowAndOpenControlUnit(10000)
+
     cy.contains('Barge – Semi-rigide 1').should('be.visible')
     cy.contains('Barge – Semi-rigide 2').should('be.visible')
   })
 
   it('Should validate the form', () => {
+    goToMainWindowAndOpenControlUnit(10000)
+
     cy.clickButton('Ajouter un moyen')
 
     cy.clickButton('Ajouter')
@@ -25,7 +25,21 @@ context('Main Window > Control Unit Dialog > Resource List', () => {
     cy.get('p').contains('Ajouter un moyen').should('not.exist')
   })
 
+  it('Should show an error dialog when trying to delete a resource linked to some missions', () => {
+    goToMainWindowAndOpenControlUnit(10121)
+
+    cy.contains('Frégate – PAM Jeanne Barret')
+      .parents('[data-cy="ControlUnitDialog-control-unit-resource"]')
+      .clickButton('Éditer ce moyen')
+    cy.clickButton('Supprimer ce moyen')
+
+    cy.get('.Component-Dialog').should('be.visible')
+    cy.contains('Suppression impossible').should('be.visible')
+  })
+
   it('Should add, edit, archive and delete a resource', () => {
+    goToMainWindowAndOpenControlUnit(10000)
+
     // -------------------------------------------------------------------------
     // Create
 
@@ -109,6 +123,8 @@ context('Main Window > Control Unit Dialog > Resource List', () => {
   })
 
   it('Should add and archive a resource', () => {
+    goToMainWindowAndOpenControlUnit(10000)
+
     // -------------------------------------------------------------------------
     // Create
 

--- a/frontend/cypress/e2e/main_window/control_unit_dialog/utils.ts
+++ b/frontend/cypress/e2e/main_window/control_unit_dialog/utils.ts
@@ -1,6 +1,6 @@
 import { goToMainWindow } from '../utils'
 
-export function gotToMainWindowAndOpenControlUnit(controlUnitId: number) {
+export function goToMainWindowAndOpenControlUnit(controlUnitId: number) {
   goToMainWindow()
 
   cy.clickButton('Liste des unités de contrôle')

--- a/frontend/cypress/e2e/side_window/mission_list/filters.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_list/filters.spec.ts
@@ -19,7 +19,7 @@ context('Side Window > Mission List > Filter Bar', () => {
   })
 
   it('Should filter missions for the current month', () => {
-    const currentDay = encodeURIComponent(customDayjs().utc().subtract(1, 'month').startOf('day').toISOString())
+    const currentDay = encodeURIComponent(customDayjs().utc().startOf('month').toISOString())
     cy.intercept('GET', `/bff/v1/missions?&startedAfterDateTime=${currentDay}*`).as('getMissions')
 
     cy.fill('Période', 'Un mois')

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@mtes-mct/monitor-ui": "10.6.0",
+        "@mtes-mct/monitor-ui": "10.9.3",
         "@reduxjs/toolkit": "1.9.5",
         "@rsuite/responsive-nav": "5.0.1",
         "@sentry/browser": "7.73.0",
@@ -4904,9 +4904,9 @@
       }
     },
     "node_modules/@mtes-mct/monitor-ui": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/@mtes-mct/monitor-ui/-/monitor-ui-10.6.0.tgz",
-      "integrity": "sha512-s8BfbBS6HhZj3G5rxS+t1ZhEXcENkFH3mO0e0d+ZAQfDGiZHfelJuFKuc9krBJwqvHyARY6lrZjOyhdACn6xnA==",
+      "version": "10.9.3",
+      "resolved": "https://registry.npmjs.org/@mtes-mct/monitor-ui/-/monitor-ui-10.9.3.tgz",
+      "integrity": "sha512-I+P+QQYW/7I9oyhpzkePOiV4ucfoKHazKz8pohWeLy4Ode4xWjGgXLC7pi2EMswrWlXu3O7+t9ViUdSicK2ryg==",
       "dependencies": {
         "@babel/runtime": "7.22.15",
         "@tanstack/react-table": "8.9.7",
@@ -4924,7 +4924,7 @@
         "react": "^18.0.0",
         "react-router-dom": "^6.0.0",
         "rsuite": "^5.37.0",
-        "styled-components": "^5.0.0"
+        "styled-components": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ndelangen/get-tarball": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "test:unit:watch": "npm run test:unit -- --watch"
   },
   "dependencies": {
-    "@mtes-mct/monitor-ui": "10.6.0",
+    "@mtes-mct/monitor-ui": "10.9.3",
     "@reduxjs/toolkit": "1.9.5",
     "@rsuite/responsive-nav": "5.0.1",
     "@sentry/browser": "7.73.0",

--- a/frontend/src/api/controlUnitResourcesAPI.ts
+++ b/frontend/src/api/controlUnitResourcesAPI.ts
@@ -1,18 +1,16 @@
 import { monitorenvPublicApi } from './api'
 import { ARCHIVE_GENERIC_ERROR_MESSAGE } from './constants'
-import { ApiErrorCode } from './types'
+import { ApiErrorCode, type BackendApiBooleanResponse } from './types'
 import { FrontendApiError } from '../libs/FrontendApiError'
 import { newUserError } from '../libs/UserError'
 
 import type { ControlUnit } from '../domain/entities/controlUnit'
 
-export const ARCHIVE_CONTROL_UNITE_RESOURCE_ERROR_MESSAGE = [
-  'Certaines unités de cette administration ne sont pas archivées.',
-  'Veuillez les archiver pour pouvoir archiver cette administration.'
-].join(' ')
-const DELETE_CONTROL_UNIT_RESOURCE_ERROR_MESSAGE =
+export const ARCHIVE_CONTROL_UNITE_RESOURCE_ERROR_MESSAGE = "Nous n'avons pas pu archiver ce moyen."
+const CAN_DELETE_CONTROL_UNIT_RESOURCE_ERROR_MESSAGE = "Nous n'avons pas pu vérifier si ce moyen est supprimable."
+export const DELETE_CONTROL_UNIT_RESOURCE_ERROR_MESSAGE =
   "Ce moyen est rattaché à des missions. Veuillez l'en détacher avant de la supprimer."
-const GET_CONTROL_UNIT_RESOURCE_ERROR_MESSAGE = "Nous n'avons pas pu récupérer cette resource."
+const GET_CONTROL_UNIT_RESOURCE_ERROR_MESSAGE = "Nous n'avons pas pu récupérer ce moyen."
 const GET_CONTROL_UNIT_RESOURCES_ERROR_MESSAGE = "Nous n'avons pas pu récupérer la liste des resources."
 
 export const controlUnitResourcesAPI = monitorenvPublicApi.injectEndpoints({
@@ -30,6 +28,13 @@ export const controlUnitResourcesAPI = monitorenvPublicApi.injectEndpoints({
 
         return new FrontendApiError(ARCHIVE_GENERIC_ERROR_MESSAGE, response)
       }
+    }),
+
+    canDeleteControlUnitResource: builder.query<boolean, number>({
+      query: controlUnitResourceId => `/v1/control_unit_resources/${controlUnitResourceId}/can_delete`,
+      transformErrorResponse: response =>
+        new FrontendApiError(CAN_DELETE_CONTROL_UNIT_RESOURCE_ERROR_MESSAGE, response),
+      transformResponse: (response: BackendApiBooleanResponse) => response.value
     }),
 
     createControlUnitResource: builder.mutation<void, ControlUnit.NewControlUnitResourceData>({
@@ -81,6 +86,7 @@ export const controlUnitResourcesAPI = monitorenvPublicApi.injectEndpoints({
 
 export const {
   useArchiveControlUnitResourceMutation,
+  useCanDeleteControlUnitResourceQuery,
   useCreateControlUnitResourceMutation,
   useDeleteControlUnitResourceMutation,
   useGetControlUnitResourceQuery,

--- a/frontend/src/api/controlUnitsAPI.ts
+++ b/frontend/src/api/controlUnitsAPI.ts
@@ -5,11 +5,11 @@ import { newUserError } from '../libs/UserError'
 
 import type { ControlUnit } from '../domain/entities/controlUnit'
 
+const CAN_DELETE_CONTROL_UNIT_ERROR_MESSAGE = "Nous n'avons pas pu vérifier si cette unité de contrôle est supprimable."
 export const DELETE_CONTROL_UNIT_ERROR_MESSAGE = [
   'Cette unité est rattachée à des missions ou des signalements.',
   "Veuillez l'en détacher avant de la supprimer ou bien l'archiver."
 ].join(' ')
-const CAN_DELETE_CONTROL_UNIT_ERROR_MESSAGE = "Nous n'avons pas pu vérifier si cette unité de contrôle est supprimable."
 const GET_CONTROL_UNIT_ERROR_MESSAGE = "Nous n'avons pas pu récupérer cette unité de contrôle."
 const GET_CONTROL_UNITS_ERROR_MESSAGE = "Nous n'avons pas pu récupérer la liste des unités de contrôle."
 

--- a/frontend/src/features/Administration/components/AdministrationTable/utils.tsx
+++ b/frontend/src/features/Administration/components/AdministrationTable/utils.tsx
@@ -55,7 +55,8 @@ export function getFilters(
 ): Filter<Administration.Administration>[] {
   const customSearch = new CustomSearch(data, ['name'], {
     cacheKey: 'BACK_OFFICE_ADMINISTRATION_LIST',
-    isStrict: true
+    isStrict: true,
+    withCacheInvalidation: true
   })
   const filters: Array<Filter<Administration.Administration>> = []
 

--- a/frontend/src/features/Base/components/BaseTable/utils.tsx
+++ b/frontend/src/features/Base/components/BaseTable/utils.tsx
@@ -32,7 +32,8 @@ export function getBaseTableColumns(
 export function getFilters(data: Base.Base[], filtersState: FiltersState): Filter<Base.Base>[] {
   const customSearch = new CustomSearch(data, ['name'], {
     cacheKey: 'BACK_OFFICE_BASE_LIST',
-    isStrict: true
+    isStrict: true,
+    withCacheInvalidation: true
   })
   const filters: Array<Filter<Base.Base>> = []
 

--- a/frontend/src/features/ControlUnit/components/ControlUnitListDialog/utils.ts
+++ b/frontend/src/features/ControlUnit/components/ControlUnitListDialog/utils.ts
@@ -49,7 +49,8 @@ export function getFilters(
     ],
     {
       cacheKey: 'MAP_CONTROL_UNIT_LIST',
-      isStrict: true
+      isStrict: true,
+      withCacheInvalidation: true
     }
   )
   const filters: Array<Filter<ControlUnit.ControlUnit>> = []

--- a/frontend/src/features/ControlUnit/components/ControlUnitTable/utils.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitTable/utils.tsx
@@ -55,7 +55,8 @@ export function getFilters(
 ): Filter<ControlUnit.ControlUnit>[] {
   const customSearch = new CustomSearch(data, ['administration.name', 'name'], {
     cacheKey: 'BACK_OFFICE_CONTROL_UNIT_LIST',
-    isStrict: true
+    isStrict: true,
+    withCacheInvalidation: true
   })
   const filters: Array<Filter<ControlUnit.ControlUnit>> = []
 

--- a/frontend/src/features/ControlUnit/usesCases/deleteControlUnitResource.ts
+++ b/frontend/src/features/ControlUnit/usesCases/deleteControlUnitResource.ts
@@ -2,6 +2,8 @@ import { logSoftError } from '@mtes-mct/monitor-ui'
 
 import { controlUnitResourcesAPI } from '../../../api/controlUnitResourcesAPI'
 import { FrontendError } from '../../../libs/FrontendError'
+import { isUserError } from '../../../libs/UserError'
+import { mainWindowActions } from '../../MainWindow/slice'
 
 import type { HomeAppThunk } from '../../../store'
 
@@ -19,10 +21,16 @@ export const deleteControlUnitResource = (): HomeAppThunk<Promise<void>> => asyn
       throw error
     }
   } catch (err) {
+    if (isUserError(err)) {
+      dispatch(mainWindowActions.openDialog({ message: err.userMessage }))
+
+      return
+    }
+
     logSoftError({
-      message: `An error happened while deleting a control unit contact (ID=${confirmationModal.entityId}").`,
+      message: `An error happened while deleting a control unit resource (ID=${confirmationModal.entityId}").`,
       originalError: err,
-      userMessage: "Une erreur est survenue pendant la suppression de l'unité de contrôle."
+      userMessage: 'Une erreur est survenue pendant la suppression du moyen.'
     })
   }
 }


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #925
- Resolve #930

----

- [x] Tests E2E (Cypress)

---

- ~~Je n'ai pas encore ajouté le test e2e (pour la dialog d'impossibilité de suppression).~~ (Done)
- La très large majeure partie du code de cette PR sont des ajouts de tests unitaires. Les fixs sont assez petits et mes commits sont bien séparés.
- Ce que je compte faire mais n'ai pas le temps de faire sur cette PR :
  - Refactorer les `deleteControlUnitContact` & `deleteControlUnitResource` use cases pour gérer les dialogs directement dans les composants concernés sans Redux. Je l'ai déjà fait pour le BackOffice dans une PR précédente.
  - Ajouter des `try {} catch {}` avec une gestion des erreurs d'archivage / suppression à posteriori (ex: au moment où on demande à supprimer un unité, elle n'est liée à aucune mission, mais au moment où on confirme, elle l'est et ne peut donc plus être supprimée).