### PR TITLE
[Missions] Impossible de modifier les unités ou moyens des anciennes missions lorsqu'il y a au moins un moyen rattaché

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/AdministrationModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/AdministrationModel.kt
@@ -66,4 +66,9 @@ data class AdministrationModel(
             controlUnits = requireNotNullList(controlUnits).map { it.toControlUnit() },
         )
     }
+
+    @Override
+    override fun toString(): String {
+        return this::class.simpleName + "(id = $id , isArchived = $isArchived , name = $name)"
+    }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/ControlUnitContactModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/ControlUnitContactModel.kt
@@ -69,4 +69,9 @@ data class ControlUnitContactModel(
             controlUnitContact = toControlUnitContact(),
         )
     }
+
+    @Override
+    override fun toString(): String {
+        return this::class.simpleName + "(id = $id , controlUnitId = ${controlUnit.id} , email = $email , name = $name , phone = $phone)"
+    }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/ControlUnitModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/ControlUnitModel.kt
@@ -114,4 +114,9 @@ data class ControlUnitModel(
             contact = "",
         )
     }
+
+    @Override
+    override fun toString(): String {
+        return this::class.simpleName + "(id = $id , administrationId = ${administration.id} , areaNote = $areaNote , departmentAreaInseeCode = ${departmentArea?.inseeCode} , isArchived = $isArchived, name = $name , termsNote = $termsNote)"
+    }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/ControlUnitResourceModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/ControlUnitResourceModel.kt
@@ -140,4 +140,9 @@ data class ControlUnitResourceModel(
             name,
         )
     }
+
+    @Override
+    override fun toString(): String {
+        return this::class.simpleName + "(id = $id , controlUnitId = ${controlUnit.id} , isArchived = $isArchived , name = $name , note = $note, name = $name , photo = $photo; stationId = ${station.id}, type = $type)"
+    }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/DepartmentAreaModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/DepartmentAreaModel.kt
@@ -39,4 +39,9 @@ data class DepartmentAreaModel(
             name,
         )
     }
+
+    @Override
+    override fun toString(): String {
+        return this::class.simpleName + "(inseeCode = $inseeCode , geometry = geometry , name = $name)"
+    }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/MissionControlResourceModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/MissionControlResourceModel.kt
@@ -15,7 +15,7 @@ data class MissionControlResourceModel(
     @JoinColumn(name = "mission_id")
     val mission: MissionModel,
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false, cascade = [CascadeType.MERGE])
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "control_resource_id")
     var resource: ControlUnitResourceModel,
 ) {

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/MissionModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/MissionModel.kt
@@ -208,7 +208,6 @@ data class MissionModel(
                     val controlUnitResourceModel = requireNotNull(controlUnitResourceModelMap[controlUnitResource.id])
 
                     MissionControlResourceModel(
-                        id = mission.id,
                         resource = controlUnitResourceModel,
                         mission = missionModel,
                     )

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/StationModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/StationModel.kt
@@ -72,4 +72,9 @@ data class StationModel(
             controlUnitResources = controlUnitResourceModels.map { it.toControlUnitResource() },
         )
     }
+
+    @Override
+    override fun toString(): String {
+        return this::class.simpleName + "(id = $id , latitude = $latitude , longitude = $longitude , name = $name)"
+    }
 }


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #955

----

- [ ] Tests E2E (Cypress)
