### PR TITLE
[Missions] Impossible de modifier les unités ou moyens des anciennes missions lorsqu'il y a au moins un moyen rattaché (bis)

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.102__fix_mission_control_resources_id_sequence.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.102__fix_mission_control_resources_id_sequence.sql
@@ -1,0 +1,1 @@
+SELECT setval('public.missions_control_resources_id_seq', (SELECT MAX(id) FROM public.missions_control_resources));


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #955

----

- [ ] Tests E2E (Cypress)
