### PR TITLE
[Missions] Tests pour filtrer les missions par unité de contrôle

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/GetMissions.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/GetMissions.kt
@@ -16,14 +16,14 @@ class GetMissions(private val missionRepository: IMissionRepository) {
     private val logger = LoggerFactory.getLogger(GetMissions::class.java)
 
     fun execute(
-        startedAfterDateTime: ZonedDateTime?,
-        startedBeforeDateTime: ZonedDateTime?,
-        missionSources: List<MissionSourceEnum>?,
-        missionTypes: List<String>?,
-        missionStatuses: List<String>?,
-        pageNumber: Int?,
-        pageSize: Int?,
-        seaFronts: List<String>?,
+        startedAfterDateTime: ZonedDateTime? = null,
+        startedBeforeDateTime: ZonedDateTime? = null,
+        missionSources: List<MissionSourceEnum>? = null,
+        missionTypes: List<String>? = null,
+        missionStatuses: List<String>? = null,
+        pageNumber: Int? = null,
+        pageSize: Int? = null,
+        seaFronts: List<String>? = null,
         controlUnits: List<Int>? = null,
     ): List<MissionEntity> {
         var missions: List<MissionEntity> =
@@ -50,7 +50,7 @@ class GetMissions(private val missionRepository: IMissionRepository) {
                 },
             )
 
-        if (controlUnits != null) {
+        if (!controlUnits.isNullOrEmpty()) {
             missions = missions.filter { mission ->
                 controlUnits.any { unitId ->
                     mission.controlUnits.any { controlUnit ->

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/GetMissionsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/GetMissionsUTests.kt
@@ -8,11 +8,11 @@ import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionTypeEnum
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionSourceEnum
 import java.time.ZonedDateTime
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 
 @ExtendWith(SpringExtension::class)
 class GetMissionsUTests {
@@ -74,24 +74,16 @@ class GetMissionsUTests {
     @Test
     fun `execute should return all missions when filter for controlUnits is null`() {
         given(missionRepository.findAll(
-            startedAfter = any(),
-            startedBefore = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            seaFronts = any(),
-            pageable = any(),
+            startedAfter = anyOrNull(),
+            startedBefore = anyOrNull(),
+            missionSources = anyOrNull(),
+            missionTypes = anyOrNull(),
+            missionStatuses = anyOrNull(),
+            seaFronts = anyOrNull(),
+            pageable = anyOrNull(),
         )).willReturn(listOf(mission1, mission2))
 
         val result = GetMissions(missionRepository).execute(
-            startedAfterDateTime = any(),
-            startedBeforeDateTime = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            pageNumber = any(),
-            pageSize = any(),
-            seaFronts = any(),
             controlUnits = null
         )
 
@@ -101,24 +93,16 @@ class GetMissionsUTests {
     @Test
     fun `execute should return all missions when filter for controlUnits is an empty list`() {
         given(missionRepository.findAll(
-            startedAfter = any(),
-            startedBefore = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            seaFronts = any(),
-            pageable = any(),
+            startedAfter = anyOrNull(),
+            startedBefore = anyOrNull(),
+            missionSources = anyOrNull(),
+            missionTypes = anyOrNull(),
+            missionStatuses = anyOrNull(),
+            seaFronts = anyOrNull(),
+            pageable = anyOrNull(),
         )).willReturn(listOf(mission1, mission2))
 
         val result = GetMissions(missionRepository).execute(
-            startedAfterDateTime = any(),
-            startedBeforeDateTime = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            pageNumber = any(),
-            pageSize = any(),
-            seaFronts = any(),
             controlUnits = listOf()
         )
 
@@ -128,52 +112,36 @@ class GetMissionsUTests {
     @Test
     fun `execute should only one missions when the controlUnits input matches 1 mission`() {
         given(missionRepository.findAll(
-            startedAfter = any(),
-            startedBefore = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            seaFronts = any(),
-            pageable = any(),
+            startedAfter = anyOrNull(),
+            startedBefore = anyOrNull(),
+            missionSources = anyOrNull(),
+            missionTypes = anyOrNull(),
+            missionStatuses = anyOrNull(),
+            seaFronts = anyOrNull(),
+            pageable = anyOrNull(),
         )).willReturn(listOf(mission1, mission2))
 
         val result = GetMissions(missionRepository).execute(
-            startedAfterDateTime = any(),
-            startedBeforeDateTime = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            pageNumber = any(),
-            pageSize = any(),
-            seaFronts = any(),
             controlUnits = listOf(controlUnit2.id)
         )
 
         assertThat(result.size).isEqualTo(1)
-        assertThat(result.first()).isEqualTo(controlUnit2)
+        assertThat(result.first()).isEqualTo(mission1)
     }
 
     @Test
     fun `execute should only two missions when the same controlUnits input matches 2 missions`() {
         given(missionRepository.findAll(
-            startedAfter = any(),
-            startedBefore = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            seaFronts = any(),
-            pageable = any(),
+            startedAfter = anyOrNull(),
+            startedBefore = anyOrNull(),
+            missionSources = anyOrNull(),
+            missionTypes = anyOrNull(),
+            missionStatuses = anyOrNull(),
+            seaFronts = anyOrNull(),
+            pageable = anyOrNull(),
         )).willReturn(listOf(mission1, mission2))
 
         val result = GetMissions(missionRepository).execute(
-            startedAfterDateTime = any(),
-            startedBeforeDateTime = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            pageNumber = any(),
-            pageSize = any(),
-            seaFronts = any(),
             controlUnits = listOf(controlUnit1.id)
         )
 
@@ -181,26 +149,18 @@ class GetMissionsUTests {
     }
 
     @Test
-    fun `execute should return filtered missions matching nultiple controlUnits input`() {
+    fun `execute should return filtered missions matching multiple controlUnits input`() {
         given(missionRepository.findAll(
-            startedAfter = any(),
-            startedBefore = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            seaFronts = any(),
-            pageable = any(),
+            startedAfter = anyOrNull(),
+            startedBefore = anyOrNull(),
+            missionSources = anyOrNull(),
+            missionTypes = anyOrNull(),
+            missionStatuses = anyOrNull(),
+            seaFronts = anyOrNull(),
+            pageable = anyOrNull(),
         )).willReturn(listOf(mission1, mission2))
 
         val result = GetMissions(missionRepository).execute(
-            startedAfterDateTime = any(),
-            startedBeforeDateTime = any(),
-            missionSources = any(),
-            missionTypes = any(),
-            missionStatuses = any(),
-            pageNumber = any(),
-            pageSize = any(),
-            seaFronts = any(),
             controlUnits = listOf(controlUnit2.id, controlUnit3.id)
         )
 

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiMissionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiMissionsControllerITests.kt
@@ -147,6 +147,7 @@ class ApiMissionsControllerITests {
                 missionTypes = any(),
                 missionStatuses = any(),
                 seaFronts = any(),
+                controlUnits = any(),
                 pageNumber = any(),
                 pageSize = any(),
             ),


### PR DESCRIPTION
## Descriptions

Réparation des tests autour des modifications sur GetMissions
Je me suis aussi rendu compte que les tests pour GetMissions n'étaient pas run. Ils le sont désormais.

----

- [ ] Tests E2E (Cypress)
