### PR TITLE
[Missions] API publique ne peut pas écrire sur les envActions

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActions.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActions.kt
@@ -1,0 +1,88 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.missions
+
+import fr.gouv.cacem.monitorenv.config.UseCase
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.ActionTypeEnum
+import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionNoteEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionSurveillanceEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionControl.EnvActionControlEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IDepartmentAreaRepository
+import fr.gouv.cacem.monitorenv.domain.repositories.IFacadeAreasRepository
+import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
+
+@UseCase
+class CreateOrUpdateEnvActions(
+    private val departmentRepository: IDepartmentAreaRepository,
+    private val facadeRepository: IFacadeAreasRepository,
+    private val missionRepository: IMissionRepository,
+) {
+    @Throws(IllegalArgumentException::class)
+    fun execute(
+        mission: MissionEntity,
+        envActions: List<EnvActionEntity>?,
+    ): MissionEntity {
+        val envActionsToSave =
+            envActions?.map {
+                when (it.actionType) {
+                    ActionTypeEnum.CONTROL -> {
+                        (it as EnvActionControlEntity).copy(
+                            facade =
+                            (it.geom ?: mission.geom)?.let { geom ->
+                                facadeRepository.findFacadeFromGeometry(geom)
+                            },
+                            department =
+                            (it.geom ?: mission.geom)?.let { geom ->
+                                departmentRepository.findDepartmentFromGeometry(
+                                    geom,
+                                )
+                            },
+                        )
+                    }
+                    ActionTypeEnum.SURVEILLANCE -> {
+                        val surveillance = it as EnvActionSurveillanceEntity
+                        /*
+                        When coverMissionZone is true, use mission geometry in priority, fall back to action geometry.
+                        When coverMissionZone is not true, prioritize the other way around.
+                        Ideally the fallbacks should not be needed, but if coverMissionZone is true and the mission geom
+                        is null, or if coverMissionZone is false and the action geom is null, then rather that nothing,
+                        better use the geometry that is available, if any.
+                         */
+                        val geometry =
+                            if (surveillance.coverMissionZone == true) {
+                                (mission.geom ?: surveillance.geom)
+                            } else {
+                                (surveillance.geom ?: mission.geom)
+                            }
+                        surveillance.copy(
+                            facade =
+                            geometry?.let { geom ->
+                                facadeRepository.findFacadeFromGeometry(geom)
+                            },
+                            department =
+                            geometry?.let { geom ->
+                                departmentRepository.findDepartmentFromGeometry(
+                                    geom,
+                                )
+                            },
+                        )
+                    }
+                    ActionTypeEnum.NOTE -> {
+                        (it as EnvActionNoteEntity).copy()
+                    }
+                }
+            }
+
+        val missionToSave =
+            mission.copy(
+                envActions = envActionsToSave,
+            )
+        val savedMission = missionRepository.save(missionToSave)
+
+        if (savedMission.mission.id == null) {
+            throw IllegalArgumentException("Mission id is null")
+        }
+
+        return savedMission.mission
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
@@ -4,11 +4,6 @@ package fr.gouv.cacem.monitorenv.domain.use_cases.missions
 
 import fr.gouv.cacem.monitorenv.config.UseCase
 import fr.gouv.cacem.monitorenv.domain.entities.mission.*
-import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.ActionTypeEnum
-import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionNoteEntity
-import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionSurveillanceEntity
-import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionControl.EnvActionControlEntity
-import fr.gouv.cacem.monitorenv.domain.repositories.IDepartmentAreaRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IFacadeAreasRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.events.UpdateMissionEvent
@@ -17,7 +12,6 @@ import org.springframework.context.ApplicationEventPublisher
 
 @UseCase
 class CreateOrUpdateMission(
-    private val departmentRepository: IDepartmentAreaRepository,
     private val facadeRepository: IFacadeAreasRepository,
     private val missionRepository: IMissionRepository,
     private val eventPublisher: ApplicationEventPublisher,
@@ -30,67 +24,13 @@ class CreateOrUpdateMission(
     ): MissionEntity {
         require(mission != null) { "No mission to create or update" }
 
-        val envActions =
-            mission.envActions?.map {
-                when (it.actionType) {
-                    ActionTypeEnum.CONTROL -> {
-                        (it as EnvActionControlEntity).copy(
-                            facade =
-                            (it.geom ?: mission.geom)?.let { geom ->
-                                facadeRepository.findFacadeFromGeometry(geom)
-                            },
-                            department =
-                            (it.geom ?: mission.geom)?.let { geom ->
-                                departmentRepository.findDepartmentFromGeometry(
-                                    geom,
-                                )
-                            },
-                        )
-                    }
-                    ActionTypeEnum.SURVEILLANCE -> {
-                        val surveillance = it as EnvActionSurveillanceEntity
-                            /*
-                            When coverMissionZone is true, use mission geometry in priority, fall back to action geometry.
-                            When coverMissionZone is not true, prioritize the other way around.
-                            Ideally the fallbacks should not be needed, but if coverMissionZone is true and the mission geom
-                            is null, or if coverMissionZone is false and the action geom is null, then rather that nothing,
-                            better use the geometry that is available, if any.
-                             */
-                        val geometry =
-                            if (surveillance.coverMissionZone == true) {
-                                (mission.geom ?: surveillance.geom)
-                            } else {
-                                (surveillance.geom ?: mission.geom)
-                            }
-                        surveillance.copy(
-                            facade =
-                            geometry?.let { geom ->
-                                facadeRepository.findFacadeFromGeometry(geom)
-                            },
-                            department =
-                            geometry?.let { geom ->
-                                departmentRepository.findDepartmentFromGeometry(
-                                    geom,
-                                )
-                            },
-                        )
-                    }
-                    ActionTypeEnum.NOTE -> {
-                        (it as EnvActionNoteEntity).copy()
-                    }
-                }
-            }
-
-        var facade: String? = null
-
-        if (mission.geom != null) {
-            facade = facadeRepository.findFacadeFromGeometry(mission.geom)
-        }
+        val facade = if (mission.geom != null) { facadeRepository.findFacadeFromGeometry(mission.geom) } else { null }
+        val storedMission = if (mission.id != null) { missionRepository.findById(mission.id) } else { null }
 
         val missionToSave =
             mission.copy(
                 facade = facade,
-                envActions = envActions,
+                envActions = storedMission?.envActions,
             )
         val savedMission = missionRepository.save(missionToSave)
 

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithActionsAndAttachedReporting.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithActionsAndAttachedReporting.kt
@@ -13,14 +13,14 @@ import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @UseCase
-class CreateOrUpdateMissionWithAttachedReporting(
+class CreateOrUpdateMissionWithActionsAndAttachedReporting(
     private val createOrUpdateMission: CreateOrUpdateMission,
     private val createOrUpdateEnvActions: CreateOrUpdateEnvActions,
     private val missionRepository: IMissionRepository,
     private val reportingRepository: IReportingRepository,
 ) {
     private val logger =
-        LoggerFactory.getLogger(CreateOrUpdateMissionWithAttachedReporting::class.java)
+        LoggerFactory.getLogger(CreateOrUpdateMissionWithActionsAndAttachedReporting::class.java)
 
     @Throws(IllegalArgumentException::class)
     fun execute(

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithAttachedReporting.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithAttachedReporting.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 @UseCase
 class CreateOrUpdateMissionWithAttachedReporting(
     private val createOrUpdateMission: CreateOrUpdateMission,
+    private val createOrUpdateEnvActions: CreateOrUpdateEnvActions,
     private val missionRepository: IMissionRepository,
     private val reportingRepository: IReportingRepository,
 ) {
@@ -39,6 +40,11 @@ class CreateOrUpdateMissionWithAttachedReporting(
 
         val savedMission = createOrUpdateMission.execute(mission)
         require(savedMission.id != null) { "The mission id is null" }
+
+        createOrUpdateEnvActions.execute(
+            savedMission,
+            mission.envActions,
+        )
 
         attachedReportingIds.forEach {
             val reporting = reportingRepository.findById(it)

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/CreateOrUpdateMissionDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/CreateOrUpdateMissionDataInput.kt
@@ -4,7 +4,6 @@ import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.LegacyControlUnitEnt
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionEntity
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionSourceEnum
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionTypeEnum
-import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionEntity
 import org.locationtech.jts.geom.MultiPolygon
 import java.time.ZonedDateTime
 
@@ -22,7 +21,6 @@ data class CreateOrUpdateMissionDataInput(
     val endDateTimeUtc: ZonedDateTime? = null,
     val missionSource: MissionSourceEnum,
     val isClosed: Boolean,
-    val envActions: List<EnvActionEntity>? = null,
     val hasMissionOrder: Boolean,
     val isUnderJdp: Boolean,
     val isGeometryComputedFromControls: Boolean,
@@ -43,7 +41,6 @@ data class CreateOrUpdateMissionDataInput(
             isClosed = this.isClosed,
             isDeleted = false,
             missionSource = this.missionSource,
-            envActions = this.envActions,
             hasMissionOrder = this.hasMissionOrder,
             isUnderJdp = this.isUnderJdp,
             isGeometryComputedFromControls = this.isGeometryComputedFromControls,

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/v1/Missions.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/v1/Missions.kt
@@ -18,8 +18,8 @@ import java.time.ZonedDateTime
 @RequestMapping("/bff/v1/missions")
 @Tag(description = "API Missions", name = "BFF.Missions")
 class Missions(
-    private val createOrUpdateMissionWithAttachedReporting:
-        CreateOrUpdateMissionWithAttachedReporting,
+    private val createOrUpdateMissionWithActionsAndAttachedReporting:
+        CreateOrUpdateMissionWithActionsAndAttachedReporting,
     private val getFullMissions: GetFullMissions,
     private val getFullMissionById: GetFullMissionById,
     private val deleteMission: DeleteMission,
@@ -32,7 +32,7 @@ class Missions(
         createMissionDataInput: CreateOrUpdateMissionDataInput,
     ): MissionDataOutput {
         val createdMission =
-            createOrUpdateMissionWithAttachedReporting.execute(
+            createOrUpdateMissionWithActionsAndAttachedReporting.execute(
                 mission = createMissionDataInput.toMissionEntity(),
                 attachedReportingIds = createMissionDataInput.attachedReportingIds,
                 envActionsAttachedToReportingIds =
@@ -128,7 +128,7 @@ class Missions(
         if ((updateMissionDataInput.id != null) && (missionId != updateMissionDataInput.id)) {
             throw java.lang.IllegalArgumentException("missionId doesn't match with request param")
         }
-        return createOrUpdateMissionWithAttachedReporting.execute(
+        return createOrUpdateMissionWithActionsAndAttachedReporting.execute(
             mission = updateMissionDataInput.toMissionEntity(),
             attachedReportingIds = updateMissionDataInput.attachedReportingIds,
             envActionsAttachedToReportingIds =

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActionsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActionsUTests.kt
@@ -9,10 +9,10 @@ import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionTypeEnum
 import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionNoteEntity
 import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionSurveillanceEntity
 import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionControl.EnvActionControlEntity
+import fr.gouv.cacem.monitorenv.domain.repositories.IDepartmentAreaRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IFacadeAreasRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.dtos.MissionDTO
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -20,65 +20,31 @@ import org.locationtech.jts.geom.MultiPoint
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.io.WKTReader
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.ZonedDateTime
 import java.util.*
 
 @ExtendWith(SpringExtension::class)
-class CreateOrUpdateMissionUTests {
+class CreateOrUpdateEnvActionsUTests {
+    @MockBean private lateinit var departmentRepository: IDepartmentAreaRepository
+
     @MockBean private lateinit var missionRepository: IMissionRepository
 
     @MockBean private lateinit var facadeAreasRepository: IFacadeAreasRepository
 
-    @MockBean private lateinit var applicationEventPublisher: ApplicationEventPublisher
-
     @Test
-    fun `execute Should throw an exception when input mission is null`() {
-        // When
-        val throwable =
-            Assertions.catchThrowable {
-                CreateOrUpdateMission(
-                    missionRepository = missionRepository,
-                    facadeRepository = facadeAreasRepository,
-                    eventPublisher = applicationEventPublisher,
-                )
-                    .execute(null)
-            }
-
-        // Then
-        assertThat(throwable).isInstanceOf(IllegalArgumentException::class.java)
-        assertThat(throwable.message).contains("No mission to create or update")
-    }
-
-    @Test
-    fun `should return the mission to update with computed facade`() {
+    fun `should return the mission to update with computed facade and department info for envActions`() {
         // Given
         val wktReader = WKTReader()
 
         val multipolygonString =
             "MULTIPOLYGON(((-2.7335 47.6078, -2.7335 47.8452, -3.6297 47.8452, -3.6297 47.6078, -2.7335 47.6078)))"
         val polygon = wktReader.read(multipolygonString) as MultiPolygon
+
         val multipointString = "MULTIPOINT((49.354105 -0.427455))"
         val point = wktReader.read(multipointString) as MultiPoint
 
-        val missionToUpdate =
-            MissionEntity(
-                id = 100,
-                missionTypes = listOf(MissionTypeEnum.LAND),
-                facade = "Outre-Mer",
-                geom = polygon,
-                startDateTimeUtc = ZonedDateTime.parse("2022-01-15T04:50:09Z"),
-                endDateTimeUtc = ZonedDateTime.parse("2022-01-23T20:29:03Z"),
-                isClosed = false,
-                missionSource = MissionSourceEnum.MONITORENV,
-                hasMissionOrder = false,
-                isDeleted = false,
-                isUnderJdp = false,
-                isGeometryComputedFromControls = false,
-            )
-
-        val existingEnvActions =
+        val envActions =
             listOf(
                 EnvActionControlEntity(
                     id =
@@ -86,8 +52,6 @@ class CreateOrUpdateMissionUTests {
                         "33310163-4e22-4d3d-b585-dac4431eb4b5",
                     ),
                     geom = point,
-                    facade = "La Face Ade",
-                    department = "Quequ'part",
                 ),
                 EnvActionSurveillanceEntity(
                     id =
@@ -95,8 +59,6 @@ class CreateOrUpdateMissionUTests {
                         "a6c4bd17-eb45-4504-ab15-7a18ea714a10",
                     ),
                     geom = polygon,
-                    facade = "La Face Ade",
-                    department = "Quequ'part",
                 ),
                 EnvActionNoteEntity(
                     id =
@@ -108,11 +70,59 @@ class CreateOrUpdateMissionUTests {
                 ),
             )
 
-        val expectedCreatedMission =
+        val updatedEnvActions = listOf(
+            EnvActionControlEntity(
+                id =
+                UUID.fromString(
+                    "33310163-4e22-4d3d-b585-dac4431eb4b5",
+                ),
+                geom = point,
+                facade = "La Face Ade",
+                department = "Quequ'part",
+            ),
+            EnvActionSurveillanceEntity(
+                id =
+                UUID.fromString(
+                    "a6c4bd17-eb45-4504-ab15-7a18ea714a10",
+                ),
+                geom = polygon,
+                facade = "La Face Ade",
+                department = "Quequ'part",
+            ),
+            EnvActionNoteEntity(
+                id =
+                UUID.fromString(
+                    "a6c4bd17-eb45-4504-ab15-7a18ea714a10",
+                ),
+                observations =
+                "Quelqu'un aurait vu quelque chose quelque part à un certain moment.",
+            ),
+        )
+
+        val missionToUpdate =
             MissionEntity(
                 id = 100,
                 endDateTimeUtc = ZonedDateTime.parse("2022-01-23T20:29:03Z"),
-                facade = "La Face Ade",
+                envActions = envActions,
+                facade = "Outre-Mer",
+                geom = polygon,
+                hasMissionOrder = false,
+                isClosed = false,
+                isDeleted = false,
+                isGeometryComputedFromControls = false,
+                isUnderJdp = false,
+                missionSource = MissionSourceEnum.MONITORENV,
+                missionTypes = listOf(MissionTypeEnum.LAND),
+                startDateTimeUtc = ZonedDateTime.parse("2022-01-15T04:50:09Z"),
+            )
+
+        val expectedUpdatedMission =
+            MissionEntity(
+                id = 100,
+                endDateTimeUtc = ZonedDateTime.parse("2022-01-23T20:29:03Z"),
+                envActions = updatedEnvActions,
+                facade = "Outre-Mer",
+                geom = polygon,
                 hasMissionOrder = false,
                 isClosed = false,
                 isDeleted = false,
@@ -124,34 +134,54 @@ class CreateOrUpdateMissionUTests {
             )
 
         given(facadeAreasRepository.findFacadeFromGeometry(anyOrNull())).willReturn("La Face Ade")
-        given(missionRepository.findById(100)).willReturn(missionToUpdate.copy(envActions = existingEnvActions))
+        given(departmentRepository.findDepartmentFromGeometry(anyOrNull())).willReturn("Quequ'part")
         given(missionRepository.save(anyOrNull()))
-            .willReturn(MissionDTO(mission = expectedCreatedMission))
+            .willReturn(MissionDTO(mission = expectedUpdatedMission))
 
         // When
         val createdMission =
-            CreateOrUpdateMission(
+            CreateOrUpdateEnvActions(
+                departmentRepository = departmentRepository,
                 missionRepository = missionRepository,
                 facadeRepository = facadeAreasRepository,
-                eventPublisher = applicationEventPublisher,
             )
                 .execute(
-                    missionToUpdate,
+                    mission = missionToUpdate,
+                    envActions = envActions,
                 )
 
         // Then
         verify(facadeAreasRepository, times(1)).findFacadeFromGeometry(argThat { this == polygon })
+        verify(facadeAreasRepository, times(1)).findFacadeFromGeometry(argThat { this == point })
+        verify(departmentRepository, times(1)).findDepartmentFromGeometry(argThat { this == polygon })
+        verify(departmentRepository, times(1)).findDepartmentFromGeometry(argThat { this == point })
 
         verify(missionRepository, times(1))
             .save(
                 argThat {
                     this ==
                         missionToUpdate.copy(
-                            facade = "La Face Ade",
-                            envActions = existingEnvActions,
+                            envActions =
+                            missionToUpdate.envActions?.map {
+                                when (it) {
+                                    is EnvActionControlEntity ->
+                                        it.copy(
+                                            facade = "La Face Ade",
+                                            department =
+                                            "Quequ'part",
+                                        )
+                                    is EnvActionSurveillanceEntity ->
+                                        it.copy(
+                                            facade = "La Face Ade",
+                                            department =
+                                            "Quequ'part",
+                                        )
+                                    else -> it
+                                }
+                            },
                         )
                 },
             )
-        assertThat(createdMission).isEqualTo(expectedCreatedMission)
+        assertThat(createdMission).isEqualTo(expectedUpdatedMission)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithActionsAndAttachedReportingUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithActionsAndAttachedReportingUTests.kt
@@ -26,7 +26,7 @@ import java.time.ZonedDateTime
 import java.util.*
 
 @ExtendWith(SpringExtension::class)
-class CreateOrUpdateMissionWithAttachedReportingUTests {
+class CreateOrUpdateMissionWithActionsAndAttachedReportingUTests {
 
     @MockBean private lateinit var createOrUpdateMission: CreateOrUpdateMission
 
@@ -91,7 +91,7 @@ class CreateOrUpdateMissionWithAttachedReportingUTests {
         given(reportingRepository.findById(3)).willReturn(getReportingDTO(3))
         // When
         val createdMissionDTO =
-            CreateOrUpdateMissionWithAttachedReporting(
+            CreateOrUpdateMissionWithActionsAndAttachedReporting(
                 createOrUpdateMission = createOrUpdateMission,
                 createOrUpdateEnvActions = createOrUpdateEnvActions,
                 missionRepository = missionRepository,
@@ -137,7 +137,7 @@ class CreateOrUpdateMissionWithAttachedReportingUTests {
 
         // Then
         assertThatThrownBy {
-            CreateOrUpdateMissionWithAttachedReporting(
+            CreateOrUpdateMissionWithActionsAndAttachedReporting(
                 createOrUpdateMission = createOrUpdateMission,
                 createOrUpdateEnvActions = createOrUpdateEnvActions,
                 missionRepository = missionRepository,
@@ -216,7 +216,7 @@ class CreateOrUpdateMissionWithAttachedReportingUTests {
 
         // When
         val createdMissionDTO =
-            CreateOrUpdateMissionWithAttachedReporting(
+            CreateOrUpdateMissionWithActionsAndAttachedReporting(
                 createOrUpdateMission = createOrUpdateMission,
                 createOrUpdateEnvActions = createOrUpdateEnvActions,
                 missionRepository = missionRepository,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithAttachedReportingUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionWithAttachedReportingUTests.kt
@@ -1,6 +1,6 @@
 @file:Suppress("ktlint:standard:package-name")
 
-package fr.gouv.cacem.monitorenv.domain.use_cases
+package fr.gouv.cacem.monitorenv.domain.use_cases.missions
 
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.given
@@ -10,8 +10,6 @@ import fr.gouv.cacem.monitorenv.domain.entities.mission.*
 import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionControl.EnvActionControlEntity
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IReportingRepository
-import fr.gouv.cacem.monitorenv.domain.use_cases.missions.CreateOrUpdateMission
-import fr.gouv.cacem.monitorenv.domain.use_cases.missions.CreateOrUpdateMissionWithAttachedReporting
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.TestUtils.getReportingDTO
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.TestUtils.getReportingDTOWithAttachedMission
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.dtos.MissionDTO
@@ -31,6 +29,8 @@ import java.util.*
 class CreateOrUpdateMissionWithAttachedReportingUTests {
 
     @MockBean private lateinit var createOrUpdateMission: CreateOrUpdateMission
+
+    @MockBean private lateinit var createOrUpdateEnvActions: CreateOrUpdateEnvActions
 
     @MockBean private lateinit var missionRepository: IMissionRepository
 
@@ -93,6 +93,7 @@ class CreateOrUpdateMissionWithAttachedReportingUTests {
         val createdMissionDTO =
             CreateOrUpdateMissionWithAttachedReporting(
                 createOrUpdateMission = createOrUpdateMission,
+                createOrUpdateEnvActions = createOrUpdateEnvActions,
                 missionRepository = missionRepository,
                 reportingRepository = reportingRepository,
             )
@@ -138,6 +139,7 @@ class CreateOrUpdateMissionWithAttachedReportingUTests {
         assertThatThrownBy {
             CreateOrUpdateMissionWithAttachedReporting(
                 createOrUpdateMission = createOrUpdateMission,
+                createOrUpdateEnvActions = createOrUpdateEnvActions,
                 missionRepository = missionRepository,
                 reportingRepository = reportingRepository,
             )
@@ -216,6 +218,7 @@ class CreateOrUpdateMissionWithAttachedReportingUTests {
         val createdMissionDTO =
             CreateOrUpdateMissionWithAttachedReporting(
                 createOrUpdateMission = createOrUpdateMission,
+                createOrUpdateEnvActions = createOrUpdateEnvActions,
                 missionRepository = missionRepository,
                 reportingRepository = reportingRepository,
             )

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/MissionsITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/MissionsITests.kt
@@ -55,8 +55,8 @@ class MissionsITests {
     @Autowired private lateinit var mockMvc: MockMvc
 
     @MockBean
-    private lateinit var createOrUpdateMissionWithAttachedReporting:
-        CreateOrUpdateMissionWithAttachedReporting
+    private lateinit var createOrUpdateMissionWithActionsAndAttachedReporting:
+        CreateOrUpdateMissionWithActionsAndAttachedReporting
 
     @MockBean private lateinit var getFullMissions: GetFullMissions
 
@@ -118,7 +118,7 @@ class MissionsITests {
             )
         val requestbody = objectMapper.writeValueAsString(newMissionRequest)
         given(
-            createOrUpdateMissionWithAttachedReporting.execute(
+            createOrUpdateMissionWithActionsAndAttachedReporting.execute(
                 mission = newMissionRequest.toMissionEntity(),
                 attachedReportingIds = listOf(),
                 envActionsAttachedToReportingIds = listOf(),
@@ -833,7 +833,7 @@ class MissionsITests {
             ) as
                 List<EnvActionAttachedToReportingIds>
         given(
-            createOrUpdateMissionWithAttachedReporting.execute(
+            createOrUpdateMissionWithActionsAndAttachedReporting.execute(
                 mission = requestBody.toMissionEntity(),
                 attachedReportingIds = listOf(1),
                 envActionsAttachedToReportingIds = envActionsAttachedToReportingIds,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiMissionsITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/ApiMissionsITests.kt
@@ -4,13 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import fr.gouv.cacem.monitorenv.config.MapperConfiguration
 import fr.gouv.cacem.monitorenv.config.WebSecurityConfig
-import fr.gouv.cacem.monitorenv.domain.entities.VehicleTypeEnum
 import fr.gouv.cacem.monitorenv.domain.entities.controlUnit.LegacyControlUnitEntity
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionEntity
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionSourceEnum
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionTypeEnum
-import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionControl.ActionTargetTypeEnum
-import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionControl.EnvActionControlEntity
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.*
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.events.UpdateMissionEvent
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.publicapi.inputs.CreateOrUpdateMissionDataInput
@@ -248,13 +245,7 @@ class ApiMissionsITests {
                 isUnderJdp = true,
                 isGeometryComputedFromControls = false,
             )
-        val envAction =
-            EnvActionControlEntity(
-                id = UUID.fromString("bf9f4062-83d3-4a85-b89b-76c0ded6473d"),
-                actionTargetType = ActionTargetTypeEnum.VEHICLE,
-                vehicleType = VehicleTypeEnum.VESSEL,
-                actionNumberOfControls = 4,
-            )
+
         val requestBody =
             CreateOrUpdateMissionDataInput(
                 id = 14,
@@ -263,7 +254,6 @@ class ApiMissionsITests {
                 observationsCnsp = "updated observations",
                 startDateTimeUtc = ZonedDateTime.parse("2022-01-15T04:50:09Z"),
                 missionSource = MissionSourceEnum.MONITORFISH,
-                envActions = listOf(envAction),
                 isClosed = false,
                 hasMissionOrder = true,
                 isUnderJdp = true,


### PR DESCRIPTION
resolves #879 

Voir si les tests sont suffisants.

Peut être un changement coté Fish à faire pour éviter d'envoyer les envActions ?