### PR TITLE
[Tech] Add lint warning for nullish coalescing operator enforcement

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
       }
     ],
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/prefer-nullish-coalescing': 'warn',
 
     'typescript-sort-keys/interface': 'error',
     'typescript-sort-keys/string-enum': 'error'


### PR DESCRIPTION
- Lorsque c'est un test booléen : ne pas remplacer `||` par `??` mais conserver le `||` tout en s'assurant que toutes le valeurs de la condition sont bien castées en booléens (`!!`).
- Lorsqu'il s'agit d'une valeur par défaut  : remplacer `||` par `??`.

La première condition n'est pas couverte par le lint, c'est à nous d'y prêter attention ^^.

## Related Pull Requests & Issues

None

----

- [ ] Tests E2E (Cypress)
