### PR TITLE
[Mission] Gestion du "multi-unité" dans une mission pour l'affichage du warning d'unité déjà en cours de mission

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/main_form.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/main_form.spec.ts
@@ -352,8 +352,19 @@ context('Side Window > Mission Form > Main Form', () => {
     cy.get('.rs-picker-search-bar-input').type('Jeanne{enter}')
     cy.wait('@getEngagedControlUnits')
     cy.get('body').contains('Une autre mission, ouverte par le CACEM, est en cours avec cette unité.')
+
+    cy.getDataCy('add-other-control-unit').should('be.disabled')
     cy.clickButton('Oui, la conserver')
-    cy.get('*[data-cy="control-unit-contact"]').type('Contact 012345')
+
+    // we want to test with a second engaged control unit
+    cy.getDataCy('add-other-control-unit').should('not.be.disabled')
+    cy.clickButton('Ajouter une autre unité')
+    cy.get('*[data-cy="add-control-unit"]').last().click()
+    cy.get('.rs-picker-search-bar-input').last().type('DML 2A{enter}')
+    cy.get('body').contains('Une autre mission, ouverte par le CACEM, est en cours avec cette unité.')
+    cy.clickButton('Oui, la conserver')
+
+    cy.get('*[data-cy="control-unit-contact"]').first().type('Contact 012345')
 
     cy.get('[name="openBy"]').scrollIntoView().type('PCF')
 

--- a/frontend/cypress/e2e/side_window/mission_form/main_form.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/main_form.spec.ts
@@ -402,7 +402,6 @@ context('Side Window > Mission Form > Main Form', () => {
 
     // When
     cy.get('*[data-cy="edit-mission-43"]').click({ force: true })
-    cy.wait('@getEngagedControlUnits')
 
     // Then
     cy.get('body').should('not.contain', 'Une autre mission, ouverte par le CACEM, est en cours avec cette unité.')

--- a/frontend/src/features/map/overlays/missions/MissionCard.tsx
+++ b/frontend/src/features/map/overlays/missions/MissionCard.tsx
@@ -74,7 +74,7 @@ export function MissionCard({ feature, isOnlyHoverable = false, selected = false
           )}
           {controlUnits?.length > 1 && controlUnits[0] && (
             <>
-              <div>{controlUnits[0].name.toUpperCase()}</div>
+              <div>{controlUnits[0].name?.toUpperCase()}</div>
               <MultipleControlUnits>
                 et {controlUnits.length - 1} {pluralize('autre', controlUnits.length - 1)}{' '}
                 {pluralize('unité', controlUnits.length - 1)}

--- a/frontend/src/features/missions/MissionForm/ControlUnitsForm/ControlUnitSelector.tsx
+++ b/frontend/src/features/missions/MissionForm/ControlUnitsForm/ControlUnitSelector.tsx
@@ -151,7 +151,7 @@ export function ControlUnitSelector({ controlUnitIndex, removeControlUnit }: Con
 
           return
         }
-        dispatch(missionFormsActions.setEngagedControlUnit(controlUnitAlreadyEngaged))
+        dispatch(missionFormsActions.setEngagedControlUnit(undefined))
       }
     }
   }

--- a/frontend/src/features/missions/MissionForm/ControlUnitsForm/ControlUnitWarningMessage.tsx
+++ b/frontend/src/features/missions/MissionForm/ControlUnitsForm/ControlUnitWarningMessage.tsx
@@ -1,10 +1,8 @@
 import { Accent, Button, Level, Message } from '@mtes-mct/monitor-ui'
 import { useField, useFormikContext } from 'formik'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import styled from 'styled-components'
 
-import { RTK_DEFAULT_QUERY_OPTIONS } from '../../../../api/constants'
-import { useGetEngagedControlUnitsQuery } from '../../../../api/missionsAPI'
 import { missionSourceEnum, type NewMission } from '../../../../domain/entities/missions'
 import { cancelCreateAndRedirectToFilteredList } from '../../../../domain/use_cases/missions/cancelCreateAndRedirectToFilteredList'
 import { useAppDispatch } from '../../../../hooks/useAppDispatch'
@@ -21,24 +19,6 @@ export function ControlUnitWarningMessage({ controlUnitIndex }: { controlUnitInd
   const engagedControlUnit = useAppSelector(state =>
     activeMissionId ? state.missionForms.missions[activeMissionId]?.engagedControlUnit : undefined
   )
-
-  const { data: engagedControlUnitsData } = useGetEngagedControlUnitsQuery(undefined, RTK_DEFAULT_QUERY_OPTIONS)
-
-  const engagedControlUnits = useMemo(() => {
-    if (!engagedControlUnitsData) {
-      return []
-    }
-
-    return engagedControlUnitsData
-  }, [engagedControlUnitsData])
-
-  const controlUnitAlreadyEngaged = engagedControlUnits.find(engaged => engaged.controlUnit.id === unitField.value)
-
-  useEffect(() => {
-    if (controlUnitAlreadyEngaged) {
-      dispatch(missionFormsActions.setEngagedControlUnit(controlUnitAlreadyEngaged))
-    }
-  }, [controlUnitAlreadyEngaged, dispatch])
 
   const message = useMemo(() => {
     if (!engagedControlUnit) {

--- a/frontend/src/features/missions/MissionForm/ControlUnitsForm/index.tsx
+++ b/frontend/src/features/missions/MissionForm/ControlUnitsForm/index.tsx
@@ -1,9 +1,14 @@
 import { Accent, Button, Icon, Size } from '@mtes-mct/monitor-ui'
 
 import { ControlUnitSelector } from './ControlUnitSelector'
+import { useAppSelector } from '../../../../hooks/useAppSelector'
 import { controlUnitFactory } from '../../Missions.helpers'
 
 export function ControlUnitsForm({ form, push, remove }) {
+  const activeMissionId = useAppSelector(state => state.missionForms.activeMissionId)
+  const engagedControlUnit = useAppSelector(state =>
+    activeMissionId ? state.missionForms.missions[activeMissionId]?.engagedControlUnit : undefined
+  )
   const handleAddControlUnit = () => {
     push(controlUnitFactory())
   }
@@ -27,7 +32,14 @@ export function ControlUnitsForm({ form, push, remove }) {
         </>
       )}
 
-      <Button accent={Accent.SECONDARY} Icon={Icon.Plus} onClick={handleAddControlUnit} size={Size.SMALL}>
+      <Button
+        accent={Accent.SECONDARY}
+        data-cy="add-other-control-unit"
+        disabled={!!engagedControlUnit}
+        Icon={Icon.Plus}
+        onClick={handleAddControlUnit}
+        size={Size.SMALL}
+      >
         Ajouter une autre unité
       </Button>
     </div>


### PR DESCRIPTION
Règle de gestion: 
- Pour la première unité, si elle est déjà en cours de mission on affiche le warning et on rend disabled le bouton permettant d'ajouter une autre unité
- Si l'utilisateur conserve la mission, le bouton d'ajout d'unité est à nouveau accessible et on répète le comportement précédent


## Related Pull Requests & Issues

- Resolve #1119


----

- [x] Tests E2E (Cypress)
