### PR TITLE
[Missions] Correction du champ `createdAtUtc` retourné lors d'un `update`

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
@@ -48,7 +48,7 @@ class CreateOrUpdateMission(
          * To fix this, we return the stored `createdAtUtc`
          */
         return savedMission.mission.copy(
-            createdAtUtc = savedMission.mission.createdAtUtc ?: storedMission?.createdAtUtc
+            createdAtUtc = savedMission.mission.createdAtUtc ?: storedMission?.createdAtUtc,
         )
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
@@ -43,6 +43,12 @@ class CreateOrUpdateMission(
             UpdateMissionEvent(savedMission.mission),
         )
 
-        return savedMission.mission
+        /**
+         * TODO When doing an update, the `createdAtUtc` field is returned as null.
+         * To fix this, we return the stored `createdAtUtc`
+         */
+        return savedMission.mission.copy(
+            createdAtUtc = savedMission.mission.createdAtUtc ?: storedMission?.createdAtUtc
+        )
     }
 }


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #1147

----

- [ ] Tests E2E (Cypress)
