### PR TITLE
[Tech] Configure les paths dans tsconfig

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,19 @@
+import { AlertUnsupportedBrowser } from '@components/AlertUnsupportedBrowser'
+import { ToastNotification } from '@components/ToastNotification'
+import { SideWindow } from '@features/SideWindow'
 import { THEME, ThemeProvider, OnlyFontGlobalStyle } from '@mtes-mct/monitor-ui'
+import { BackOfficePage } from '@pages/BackOfficePage'
+import { HomePage } from '@pages/HomePage'
+import { homeStore } from '@store/index'
+import { isBrowserSupported } from '@utils/isBrowserSupported'
+import { isCypress } from '@utils/isCypress'
 import { Provider as ReduxProvider } from 'react-redux'
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
 import { persistStore } from 'redux-persist'
 import { PersistGate } from 'redux-persist/integration/react'
 import { CustomProvider as RsuiteCustomProvider } from 'rsuite'
 
-import { AlertUnsupportedBrowser } from './components/AlertUnsupportedBrowser'
-import { ToastNotification } from './components/ToastNotification'
-import { SideWindow } from './features/SideWindow'
-import { BackOfficePage } from './pages/BackOfficePage'
-import { HomePage } from './pages/HomePage'
-import { homeStore } from './store'
 import { FR_FR_LOCALE } from './uiMonitor/locale_frFR'
-import { isBrowserSupported } from './utils/isBrowserSupported'
-import { isCypress } from './utils/isCypress'
 
 export function App() {
   if (!isBrowserSupported()) {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,10 +1,10 @@
 import { BrowserTracing } from '@sentry/browser'
 import { init } from '@sentry/react'
+import { measureScrollbarWidth } from '@utils/styleHelpers'
 import { isEmpty } from 'lodash'
 import { createRoot } from 'react-dom/client'
 
 import { App } from './App'
-import { measureScrollbarWidth } from './utils/styleHelpers'
 
 import 'rsuite/dist/rsuite.min.css'
 import 'ol/ol.css'

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
+    "baseUrl": "./src",
     "checkJs": false,
     // Override inherited value for CommonJS > ESM compatibility purpose
     "esModuleInterop": true,
@@ -15,6 +16,16 @@
     // https://github.com/cypress-io/cypress/issues/26308#issuecomment-1666236726
     "module": "ESNext",
     "moduleResolution": "Node",
+    "paths": {
+      "@api/*": ["api/*"],
+      "@components/*": ["components/*"],
+      "@features/*": ["features/*"],
+      "@hooks/*": ["hooks/*"],
+      "@libs/*": ["libs/*"],
+      "@pages/*": ["pages/*"],
+      "@store/*": ["store/*"],
+      "@utils/*": ["utils/*"]
+    },
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": false,


### PR DESCRIPTION
- J'aurais pu mettre un `"@/*": ["*"],` mais je préfère être déclaratif pour ne garder que les paths qui correspondent à notre structure "officielle".
- La raison pour laquelle je n'ai pas mis les dossiers `context/`, `errors/` et `workers/` et que j'aimerais challenger leur emplacement actuel.

## Related Pull Requests & Issues

- MTES-MCT/monitorfish#2886

----

- [ ] Tests E2E (Cypress)
