### PR TITLE
[Geometries] Normalisation des géométries pour les missions, envActions et signalements

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IPostgisFunctionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IPostgisFunctionRepository.kt
@@ -1,0 +1,9 @@
+package fr.gouv.cacem.monitorenv.domain.repositories
+
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.MultiPolygon
+
+interface IPostgisFunctionRepository {
+    fun normalizeMultipolygon(geometry: MultiPolygon): MultiPolygon
+    fun normalizeGeometry(geometry: Geometry): Geometry
+}

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActions.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActions.kt
@@ -35,18 +35,18 @@ class CreateOrUpdateEnvActions(
                         control.copy(
                             geom = normalizedControlPoint,
                             facade =
-                            (normalizedControlPoint ?: mission.geom)?.let { nonNullGeom ->
+                            normalizedControlPoint?.let { nonNullGeom ->
                                 facadeRepository.findFacadeFromGeometry(nonNullGeom)
                             },
                             department =
-                            (normalizedControlPoint ?: mission.geom)?.let { nonNullGeom ->
+                            normalizedControlPoint?.let { nonNullGeom ->
                                 departmentRepository.findDepartmentFromGeometry(nonNullGeom)
                             },
                         )
                     }
                     ActionTypeEnum.SURVEILLANCE -> {
                         val surveillance = it as EnvActionSurveillanceEntity
-                        val normalizedGeometry = (surveillance.geom ?: mission.geom)?.let { nonNullGeom ->
+                        val normalizedGeometry = surveillance.geom?.let { nonNullGeom ->
                             postgisFunctionRepository.normalizeGeometry(nonNullGeom)
                         }
 

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActions.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActions.kt
@@ -29,42 +29,35 @@ class CreateOrUpdateEnvActions(
                 when (it.actionType) {
                     ActionTypeEnum.CONTROL -> {
                         val control = it as EnvActionControlEntity
-                        val normalizedControlPoint = if (control.geom != null) {
-                            postgisFunctionRepository.normalizeGeometry(control.geom)
-                        } else {
-                            null
+                        val normalizedControlPoint = control.geom?.let { nonNullGeom ->
+                            postgisFunctionRepository.normalizeGeometry(nonNullGeom)
                         }
                         control.copy(
                             geom = normalizedControlPoint,
                             facade =
-                            (normalizedControlPoint ?: mission.geom)?.let { g ->
-                                facadeRepository.findFacadeFromGeometry(g)
+                            (normalizedControlPoint ?: mission.geom)?.let { nonNullGeom ->
+                                facadeRepository.findFacadeFromGeometry(nonNullGeom)
                             },
                             department =
-                            (normalizedControlPoint ?: mission.geom)?.let { g ->
-                                departmentRepository.findDepartmentFromGeometry(
-                                    g,
-                                )
+                            (normalizedControlPoint ?: mission.geom)?.let { nonNullGeom ->
+                                departmentRepository.findDepartmentFromGeometry(nonNullGeom)
                             },
                         )
                     }
                     ActionTypeEnum.SURVEILLANCE -> {
                         val surveillance = it as EnvActionSurveillanceEntity
-
-                        val normalizedGeometry = if (surveillance.geom != null) {
-                            postgisFunctionRepository.normalizeGeometry(surveillance.geom)
-                        } else {
-                            null
+                        val normalizedGeometry = (surveillance.geom ?: mission.geom)?.let { nonNullGeom ->
+                            postgisFunctionRepository.normalizeGeometry(nonNullGeom)
                         }
-                        val geometry = surveillance.geom ?: mission.geom
 
                         surveillance.copy(
+                            geom = normalizedGeometry,
                             facade =
-                            geometry?.let { geom ->
+                            normalizedGeometry?.let { geom ->
                                 facadeRepository.findFacadeFromGeometry(geom)
                             },
                             department =
-                            geometry?.let { geom ->
+                            normalizedGeometry?.let { geom ->
                                 departmentRepository.findDepartmentFromGeometry(
                                     geom,
                                 )

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMission.kt
@@ -25,20 +25,14 @@ class CreateOrUpdateMission(
         mission: MissionEntity?,
     ): MissionEntity {
         require(mission != null) { "No mission to create or update" }
-        val normalizedMission = if (mission.geom != null) {
-            mission.copy(
-                geom = postgisFunctionRepository.normalizeMultipolygon(mission.geom),
-            )
-        } else {
-            mission
-        }
+        val normalizedMission = mission.geom?.let { nonNullGeom ->
+            mission.copy(geom = postgisFunctionRepository.normalizeMultipolygon(nonNullGeom))
+        } ?: mission
 
-        val facade = if (normalizedMission.geom != null) {
-            facadeRepository.findFacadeFromGeometry(
-                normalizedMission.geom,
-            )
-        } else { null }
-        val storedMission = if (normalizedMission.id != null) { missionRepository.findById(normalizedMission.id) } else { null }
+        val facade = normalizedMission.geom?.let { nonNullGeom ->
+            facadeRepository.findFacadeFromGeometry(nonNullGeom)
+        }
+        val storedMission = normalizedMission.id?.let { id -> missionRepository.findById(id) }
 
         val missionToSave =
             normalizedMission.copy(

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/reportings/CreateOrUpdateReporting.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/reportings/CreateOrUpdateReporting.kt
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory
 class CreateOrUpdateReporting(
     private val reportingRepository: IReportingRepository,
     private val facadeRepository: IFacadeAreasRepository,
+    private val postgisFunctionRepository: IPostgisFunctionRepository,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(CreateOrUpdateReporting::class.java)
 
@@ -36,15 +37,23 @@ class CreateOrUpdateReporting(
                 )
             }
         }
+        val normalizedGeometry = if (reporting.geom != null) {
+            postgisFunctionRepository.normalizeGeometry(
+                reporting.geom,
+            )
+        } else {
+            null
+        }
 
-        val seaFront = if (reporting.geom != null) {
-            facadeRepository.findFacadeFromGeometry(reporting.geom)
+        val seaFront = if (normalizedGeometry != null) {
+            facadeRepository.findFacadeFromGeometry(normalizedGeometry)
         } else {
             null
         }
 
         return reportingRepository.save(
             reporting.copy(
+                geom = normalizedGeometry,
                 seaFront = seaFront,
             ),
         )

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaPostgisFunctionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaPostgisFunctionRepository.kt
@@ -1,0 +1,43 @@
+package fr.gouv.cacem.monitorenv.infrastructure.database.repositories
+
+import fr.gouv.cacem.monitorenv.domain.repositories.IPostgisFunctionRepository
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
+import org.springframework.stereotype.Repository
+
+@Repository
+class JpaPostgisFunctionRepository : IPostgisFunctionRepository {
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun normalizeMultipolygon(geometry: MultiPolygon): MultiPolygon {
+        return entityManager.createNativeQuery(
+            """
+         SELECT CASE
+            WHEN st_xmax(:geom)> 230 OR st_xmin(:geom)<-205
+                THEN CAST(CAST(:geom AS geography) AS geometry)
+            ELSE :geom END
+            """.trimIndent(),
+            MultiPolygon::class.java,
+        )
+            .setParameter("geom", geometry)
+            .singleResult as MultiPolygon
+    }
+
+    override fun normalizeGeometry(geometry: Geometry): Geometry {
+        return entityManager.createNativeQuery(
+            """
+         SELECT CASE
+            WHEN st_xmax(:geom)> 230 OR st_xmin(:geom)<-205
+                THEN CAST(CAST(:geom AS geography) AS geometry)
+            ELSE :geom END
+            """.trimIndent(),
+            Geometry::class.java,
+        )
+            .setParameter("geom", geometry)
+            .singleResult as Point
+    }
+}

--- a/backend/src/main/resources/db/migration/internal/V0.116__fix_geometries.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.116__fix_geometries.sql
@@ -1,3 +1,0 @@
-UPDATE missions set geom = st_astext(CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END);
-UPDATE env_actions set geom = st_astext(CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END);
-UPDATE reportings set geom = st_astext(CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END);

--- a/backend/src/main/resources/db/migration/internal/V0.116__fix_geometries.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.116__fix_geometries.sql
@@ -1,0 +1,3 @@
+UPDATE missions set geom = st_astext(CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END);
+UPDATE env_actions set geom = st_astext(CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END);
+UPDATE reportings set geom = st_astext(CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END);

--- a/backend/src/main/resources/db/migration/internal/V0.121__fix_geometries.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.121__fix_geometries.sql
@@ -1,0 +1,3 @@
+UPDATE missions set geom = CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END;
+UPDATE env_actions set geom = CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END;
+UPDATE reportings set geom = CASE WHEN st_xmax(geom)> 230 OR st_xmin(geom)<-205 THEN geom::geography::geometry ELSE geom END;

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/CreateOrUpdateReportingUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/CreateOrUpdateReportingUTests.kt
@@ -15,6 +15,7 @@ import fr.gouv.cacem.monitorenv.domain.exceptions.ReportingAlreadyAttachedExcept
 import fr.gouv.cacem.monitorenv.domain.repositories.IControlUnitRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IFacadeAreasRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
+import fr.gouv.cacem.monitorenv.domain.repositories.IPostgisFunctionRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IReportingRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.ISemaphoreRepository
 import fr.gouv.cacem.monitorenv.domain.use_cases.controlUnit.dtos.FullControlUnitDTO
@@ -44,6 +45,8 @@ class CreateOrUpdateReportingUTests {
 
     @MockBean private lateinit var missionRepository: IMissionRepository
 
+    @MockBean private lateinit var postgisFunctionRepository: IPostgisFunctionRepository
+
     @Test
     fun `Should throw an exception when input is null`() {
         // When
@@ -52,6 +55,7 @@ class CreateOrUpdateReportingUTests {
                 CreateOrUpdateReporting(
                     reportingRepository = reportingRepository,
                     facadeRepository = facadeRepository,
+                    postgisFunctionRepository = postgisFunctionRepository,
                 )
                     .execute(null)
             }
@@ -197,16 +201,19 @@ class CreateOrUpdateReportingUTests {
         given(facadeRepository.findFacadeFromGeometry(polygon)).willReturn("Facade 1")
         given(semaphoreRepository.findById(1)).willReturn(semaphore)
         given(controlUnitRepository.findById(1)).willReturn(fullControlUnit)
+        given(postgisFunctionRepository.normalizeGeometry(polygon)).willReturn(polygon)
 
         // When
         val createdReportingWithSemaphore =
             CreateOrUpdateReporting(
                 reportingRepository = reportingRepository,
                 facadeRepository = facadeRepository,
+                postgisFunctionRepository = postgisFunctionRepository,
             )
                 .execute(reportingWithSemaphore)
 
         // Then
+        verify(postgisFunctionRepository, times(1)).normalizeGeometry(polygon)
         verify(reportingRepository, times(1)).save(reportingWithSemaphore)
         assertThat(createdReportingWithSemaphore).isEqualTo(reportingWithSemaphoreDTO)
 
@@ -215,6 +222,7 @@ class CreateOrUpdateReportingUTests {
             CreateOrUpdateReporting(
                 reportingRepository = reportingRepository,
                 facadeRepository = facadeRepository,
+                postgisFunctionRepository = postgisFunctionRepository,
             )
                 .execute(reportingWithControlUnit)
 
@@ -259,6 +267,7 @@ class CreateOrUpdateReportingUTests {
                 CreateOrUpdateReporting(
                     reportingRepository = reportingRepository,
                     facadeRepository = facadeRepository,
+                    postgisFunctionRepository = postgisFunctionRepository,
                 )
                     .execute(reporting)
             }
@@ -305,6 +314,7 @@ class CreateOrUpdateReportingUTests {
                 CreateOrUpdateReporting(
                     reportingRepository = reportingRepository,
                     facadeRepository = facadeRepository,
+                    postgisFunctionRepository = postgisFunctionRepository,
                 )
                     .execute(reporting)
             }
@@ -391,6 +401,7 @@ class CreateOrUpdateReportingUTests {
                 CreateOrUpdateReporting(
                     reportingRepository = reportingRepository,
                     facadeRepository = facadeRepository,
+                    postgisFunctionRepository = postgisFunctionRepository,
                 )
                     .execute(reportingWithControlUnitId)
             }
@@ -406,6 +417,7 @@ class CreateOrUpdateReportingUTests {
                 CreateOrUpdateReporting(
                     reportingRepository = reportingRepository,
                     facadeRepository = facadeRepository,
+                    postgisFunctionRepository = postgisFunctionRepository,
                 )
                     .execute(reportingWithSemaphoreId)
             }
@@ -421,6 +433,7 @@ class CreateOrUpdateReportingUTests {
                 CreateOrUpdateReporting(
                     reportingRepository = reportingRepository,
                     facadeRepository = facadeRepository,
+                    postgisFunctionRepository = postgisFunctionRepository,
                 )
                     .execute(reportingWithoutSourceName)
             }
@@ -502,6 +515,7 @@ class CreateOrUpdateReportingUTests {
             CreateOrUpdateReporting(
                 reportingRepository = reportingRepository,
                 facadeRepository = facadeRepository,
+                postgisFunctionRepository = postgisFunctionRepository,
             )
                 .execute(reportingWithNewAttachedMission)
         }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActionsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateEnvActionsUTests.kt
@@ -12,6 +12,7 @@ import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionContr
 import fr.gouv.cacem.monitorenv.domain.repositories.IDepartmentAreaRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IFacadeAreasRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
+import fr.gouv.cacem.monitorenv.domain.repositories.IPostgisFunctionRepository
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.dtos.MissionDTO
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -31,6 +32,8 @@ class CreateOrUpdateEnvActionsUTests {
     @MockBean private lateinit var missionRepository: IMissionRepository
 
     @MockBean private lateinit var facadeAreasRepository: IFacadeAreasRepository
+
+    @MockBean private lateinit var postgisFunctionRepository: IPostgisFunctionRepository
 
     @Test
     fun `should return the mission to update with computed facade and department info for envActions`() {
@@ -133,6 +136,8 @@ class CreateOrUpdateEnvActionsUTests {
                 startDateTimeUtc = ZonedDateTime.parse("2022-01-15T04:50:09Z"),
             )
 
+        given(postgisFunctionRepository.normalizeGeometry(point)).willReturn(point)
+        given(postgisFunctionRepository.normalizeGeometry(polygon)).willReturn(polygon)
         given(facadeAreasRepository.findFacadeFromGeometry(anyOrNull())).willReturn("La Face Ade")
         given(departmentRepository.findDepartmentFromGeometry(anyOrNull())).willReturn("Quequ'part")
         given(missionRepository.save(anyOrNull()))
@@ -144,6 +149,7 @@ class CreateOrUpdateEnvActionsUTests {
                 departmentRepository = departmentRepository,
                 missionRepository = missionRepository,
                 facadeRepository = facadeAreasRepository,
+                postgisFunctionRepository = postgisFunctionRepository,
             )
                 .execute(
                     mission = missionToUpdate,
@@ -151,10 +157,12 @@ class CreateOrUpdateEnvActionsUTests {
                 )
 
         // Then
-        verify(facadeAreasRepository, times(1)).findFacadeFromGeometry(argThat { this == polygon })
+        // verify(facadeAreasRepository, times(1)).findFacadeFromGeometry(argThat { this == polygon })
         verify(facadeAreasRepository, times(1)).findFacadeFromGeometry(argThat { this == point })
         verify(departmentRepository, times(1)).findDepartmentFromGeometry(argThat { this == polygon })
         verify(departmentRepository, times(1)).findDepartmentFromGeometry(argThat { this == point })
+        verify(postgisFunctionRepository, times(1)).normalizeGeometry(argThat { this == point })
+        verify(postgisFunctionRepository, times(1)).normalizeGeometry(argThat { this == polygon })
 
         verify(missionRepository, times(1))
             .save(

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/CreateOrUpdateMissionUTests.kt
@@ -11,6 +11,7 @@ import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.EnvActionSurve
 import fr.gouv.cacem.monitorenv.domain.entities.mission.envAction.envActionControl.EnvActionControlEntity
 import fr.gouv.cacem.monitorenv.domain.repositories.IFacadeAreasRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
+import fr.gouv.cacem.monitorenv.domain.repositories.IPostgisFunctionRepository
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.dtos.MissionDTO
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -31,6 +32,8 @@ class CreateOrUpdateMissionUTests {
 
     @MockBean private lateinit var facadeAreasRepository: IFacadeAreasRepository
 
+    @MockBean private lateinit var postgisFunctionRepository: IPostgisFunctionRepository
+
     @MockBean private lateinit var applicationEventPublisher: ApplicationEventPublisher
 
     @Test
@@ -42,6 +45,7 @@ class CreateOrUpdateMissionUTests {
                     missionRepository = missionRepository,
                     facadeRepository = facadeAreasRepository,
                     eventPublisher = applicationEventPublisher,
+                    postgisFunctionRepository = postgisFunctionRepository,
                 )
                     .execute(null)
             }
@@ -125,6 +129,7 @@ class CreateOrUpdateMissionUTests {
                 startDateTimeUtc = ZonedDateTime.parse("2022-01-15T04:50:09Z"),
             )
 
+        given(postgisFunctionRepository.normalizeMultipolygon(polygon)).willReturn(polygon)
         given(facadeAreasRepository.findFacadeFromGeometry(anyOrNull())).willReturn("La Face Ade")
         given(missionRepository.findById(100)).willReturn(missionToUpdate.copy(envActions = existingEnvActions))
         given(missionRepository.save(anyOrNull()))
@@ -136,6 +141,7 @@ class CreateOrUpdateMissionUTests {
                 missionRepository = missionRepository,
                 facadeRepository = facadeAreasRepository,
                 eventPublisher = applicationEventPublisher,
+                postgisFunctionRepository = postgisFunctionRepository,
             )
                 .execute(
                     missionToUpdate,
@@ -143,6 +149,7 @@ class CreateOrUpdateMissionUTests {
 
         // Then
         verify(facadeAreasRepository, times(1)).findFacadeFromGeometry(argThat { this == polygon })
+        verify(postgisFunctionRepository, times(1)).normalizeMultipolygon(argThat { this == polygon })
 
         verify(missionRepository, times(1))
             .save(
@@ -205,6 +212,7 @@ class CreateOrUpdateMissionUTests {
                 missionRepository = missionRepository,
                 facadeRepository = facadeAreasRepository,
                 eventPublisher = applicationEventPublisher,
+                postgisFunctionRepository = postgisFunctionRepository,
             )
                 .execute(
                     missionToUpdate,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaPostgisFunctionRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaPostgisFunctionRepositoryITests.kt
@@ -1,0 +1,74 @@
+package fr.gouv.cacem.monitorenv.infrastructure.database.repositories
+
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.io.WKTReader
+import org.springframework.beans.factory.annotation.Autowired
+
+class JpaPostgisFunctionRepositoryITests : AbstractDBTests() {
+
+    @Autowired
+    private lateinit var jpaPostgisFunctionRepository: JpaPostgisFunctionRepository
+
+    @Test
+    @Transactional
+    fun `normalizeMultipolygon Should return normalized multipolygon`() {
+        // Given
+        val polygonThatCrosses180lineButOk = WKTReader().read(
+            "MULTIPOLYGON(((169.5414367971761 -12.021383335554233,170.84621026404997 -20.474226402870727,192.99614452466446 -16.801786171979174,191.18757796238393 -7.314652241379889,177.13555525730285 -7.816976931074834,169.5414367971761 -12.021383335554233)))",
+        ) as MultiPolygon
+        val polygonThatCrosses180lineButNotOk = WKTReader().read(
+            "MULTIPOLYGON(((2152.946141283657 47.482021414897076,2153.3382158686177 46.05043975867042,2156.0387926508447 46.18608925819626,2155.1049547602192 47.52469665125105,2152.946141283657 47.482021414897076)))",
+        ) as MultiPolygon
+
+        val expectedNormalizedPolygon = WKTReader().read(
+            "MULTIPOLYGON(((-7.053858716342802 47.482021414897076,-6.661784131382319 46.05043975867042,-3.961207349155302 46.18608925819626,-4.895045239780757 47.52469665125105,-7.053858716342802 47.482021414897076)))",
+        ) as MultiPolygon
+
+        // When
+        val untouchedMultipolygon = jpaPostgisFunctionRepository.normalizeMultipolygon(polygonThatCrosses180lineButOk)
+        val normalizedMultipolygon = jpaPostgisFunctionRepository.normalizeMultipolygon(
+            polygonThatCrosses180lineButNotOk,
+        )
+
+        // Then
+        assertThat(untouchedMultipolygon).isEqualTo(polygonThatCrosses180lineButOk)
+        assertThat(normalizedMultipolygon).isEqualTo(expectedNormalizedPolygon)
+    }
+
+    @Test
+    @Transactional
+    fun `normalizeGeometry Should return normalized geometry`() {
+        // Given
+        val polygonThatCrosses180lineButOk = WKTReader().read(
+            "MULTIPOLYGON(((169.5414367971761 -12.021383335554233,170.84621026404997 -20.474226402870727,192.99614452466446 -16.801786171979174,191.18757796238393 -7.314652241379889,177.13555525730285 -7.816976931074834,169.5414367971761 -12.021383335554233)))",
+        ) as MultiPolygon
+        val polygonThatCrosses180lineButNotOk = WKTReader().read(
+            "MULTIPOLYGON(((2152.946141283657 47.482021414897076,2153.3382158686177 46.05043975867042,2156.0387926508447 46.18608925819626,2155.1049547602192 47.52469665125105,2152.946141283657 47.482021414897076)))",
+        ) as MultiPolygon
+
+        val pointOutOfBounds = WKTReader().read("POINT(2152.946141283657 47.482021414897076)") as Point
+        val pointInBounds = WKTReader().read("POINT(169.5414367971761 -12.021383335554233)") as Point
+
+        val expectedNormalizedPolygon = WKTReader().read(
+            "MULTIPOLYGON(((-7.053858716342802 47.482021414897076,-6.661784131382319 46.05043975867042,-3.961207349155302 46.18608925819626,-4.895045239780757 47.52469665125105,-7.053858716342802 47.482021414897076)))",
+        ) as MultiPolygon
+        val expectedPointOutOfBoundsNormalized = WKTReader().read("POINT(-7.053858716342802 47.482021414897076)") as Point
+        // When
+        val untouchedMultipolygon = jpaPostgisFunctionRepository.normalizeMultipolygon(polygonThatCrosses180lineButOk)
+        val normalizedMultipolygon = jpaPostgisFunctionRepository.normalizeMultipolygon(
+            polygonThatCrosses180lineButNotOk,
+        )
+
+        // Then
+        assertThat(untouchedMultipolygon).isEqualTo(polygonThatCrosses180lineButOk)
+        assertThat(normalizedMultipolygon).isEqualTo(expectedNormalizedPolygon)
+        assertThat(jpaPostgisFunctionRepository.normalizeGeometry(pointOutOfBounds)).isEqualTo(
+            expectedPointOutOfBoundsNormalized,
+        )
+        assertThat(jpaPostgisFunctionRepository.normalizeGeometry(pointInBounds)).isEqualTo(pointInBounds)
+    }
+}


### PR DESCRIPTION
relates to #461 

A compléter avec un fix front

On normalise les géométries uniquement lorsqu'elles sont tracées au delà de 230° et non 180° car on veut pouvoir quand même visualiser correctement les zones tracées à proximité de la ligne de franchissement des 180° (Wallis et Futuna / Papette)

A vérifier que l'on a bien les façades à ces coordonnées.