### PR TITLE
[Mission] Résolution du bug de duplication de mission à la création

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/main_form.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/main_form.spec.ts
@@ -75,9 +75,9 @@ context('Side Window > Mission Form > Main Form', () => {
 
   it('A mission should be created When auto-save is not enabled', () => {
     // Given
+    cy.intercept('GET', '/bff/v1/missions*').as('getMissions')
     visitSideWindow('false')
 
-    cy.intercept('GET', '/bff/v1/missions*').as('getMissions')
     cy.wait('@getMissions')
     cy.wait(400) // a first render with 0 missions is likely to happen
     cy.get('*[data-cy="Missions-numberOfDisplayedMissions"]').then($el => {

--- a/frontend/src/domain/use_cases/missions/saveMission.ts
+++ b/frontend/src/domain/use_cases/missions/saveMission.ts
@@ -42,28 +42,33 @@ export const saveMission =
 
         // We save the new properties : `id`, `createdAt`, `updatedAt` after a mission creation/update
         if (missionIsNewMission) {
-          const nextPath = generatePath(sideWindowPaths.MISSION, { id: missionUpdated.id })
-          await dispatch(missionFormsActions.deleteSelectedMission(values.id))
-          dispatch(
-            missionFormsActions.setMission({
-              engagedControlUnit: undefined,
-              isFormDirty: false,
-              missionForm: response.data
+          await dispatch(
+            missionFormsActions.setCreatedMission({
+              createdMission: {
+                engagedControlUnit: undefined,
+                isFormDirty: false,
+                missionForm: missionUpdated
+              },
+              newId: values.id
             })
           )
+
           await dispatch(missionActions.setSelectedMissionIdOnMap(missionUpdated.id))
-          dispatch(sideWindowActions.setCurrentPath(nextPath))
-        } else {
-          // for a mission already created we want to update the `updatedAt` value with the new one
-          const mission = selectedMissions[values.id]
-          dispatch(
-            missionFormsActions.setMission({
-              ...mission,
-              isFormDirty: false, // since misison has just been saved, it's not dirty anymore
-              missionForm: response.data
-            })
-          )
+          const nextPath = generatePath(sideWindowPaths.MISSION, { id: missionUpdated.id })
+          await dispatch(sideWindowActions.setCurrentPath(nextPath))
+
+          return
         }
+
+        // for a mission already created we want to update the `updatedAt` value with the new one
+        const mission = selectedMissions[values.id]
+        dispatch(
+          missionFormsActions.setMission({
+            ...mission,
+            isFormDirty: false, // since mission has just been saved, it's not dirty anymore
+            missionForm: response.data
+          })
+        )
 
         if (reopen || !quitAfterSave) {
           return

--- a/frontend/src/domain/use_cases/missions/saveMission.ts
+++ b/frontend/src/domain/use_cases/missions/saveMission.ts
@@ -56,25 +56,23 @@ export const saveMission =
           await dispatch(missionActions.setSelectedMissionIdOnMap(missionUpdated.id))
           const nextPath = generatePath(sideWindowPaths.MISSION, { id: missionUpdated.id })
           await dispatch(sideWindowActions.setCurrentPath(nextPath))
-
-          return
+        } else {
+          // for a mission already created we want to update the `updatedAt` value with the new one
+          const mission = selectedMissions[values.id]
+          dispatch(
+            missionFormsActions.setMission({
+              ...mission,
+              isFormDirty: false, // since mission has just been saved, it's not dirty anymore
+              missionForm: missionUpdated
+            })
+          )
         }
-
-        // for a mission already created we want to update the `updatedAt` value with the new one
-        const mission = selectedMissions[values.id]
-        dispatch(
-          missionFormsActions.setMission({
-            ...mission,
-            isFormDirty: false, // since mission has just been saved, it's not dirty anymore
-            missionForm: response.data
-          })
-        )
 
         if (reopen || !quitAfterSave) {
           return
         }
 
-        await dispatch(missionFormsActions.deleteSelectedMission(values.id))
+        await dispatch(missionFormsActions.deleteSelectedMission(missionUpdated.id))
         dispatch(updateMapInteractionListeners(MapInteractionListenerEnum.NONE))
         dispatch(sideWindowActions.focusAndGoTo(sideWindowPaths.MISSIONS))
 

--- a/frontend/src/domain/use_cases/missions/saveMission.ts
+++ b/frontend/src/domain/use_cases/missions/saveMission.ts
@@ -49,7 +49,7 @@ export const saveMission =
                 isFormDirty: false,
                 missionForm: missionUpdated
               },
-              newId: values.id
+              previousId: values.id
             })
           )
 

--- a/frontend/src/features/map/layers/Reportings/style.ts
+++ b/frontend/src/features/map/layers/Reportings/style.ts
@@ -263,7 +263,7 @@ const attachedMissionCircleStyle = new Style({
     return missionCenter && new Point(missionCenter)
   },
   image: new Circle({
-    displacement: [0, 27],
+    displacement: [0, 23],
     radius: 20,
     stroke: new Stroke({
       color: THEME.color.charcoal,

--- a/frontend/src/features/missions/MissionForm/hooks/useSyncFormValuesWithRedux.ts
+++ b/frontend/src/features/missions/MissionForm/hooks/useSyncFormValuesWithRedux.ts
@@ -13,7 +13,9 @@ export function useSyncFormValuesWithRedux(isAutoSaveEnabled: boolean) {
   const dispatch = useAppDispatch()
   const { dirty, validateForm, values } = useFormikContext<Mission>()
   const activeMissionId = useAppSelector(state => state.missionForms.activeMissionId)
-  const selectedMissions = useAppSelector(state => state.missionForms.missions)
+  const activeMission = useAppSelector(state =>
+    activeMissionId ? state.missionForms.missions[activeMissionId] : undefined
+  )
   const engagedControlUnit = useAppSelector(state =>
     activeMissionId ? state.missionForms.missions[activeMissionId]?.engagedControlUnit : undefined
   )
@@ -27,7 +29,7 @@ export function useSyncFormValuesWithRedux(isAutoSaveEnabled: boolean) {
     const isFormDirty = isMissionFormDirty(errors)
 
     dispatch(missionFormsActions.setMission({ engagedControlUnit, isFormDirty, missionForm: newValues }))
-  }, 500)
+  }, 250)
 
   /**
    * The form is dirty if:
@@ -45,7 +47,7 @@ export function useSyncFormValuesWithRedux(isAutoSaveEnabled: boolean) {
        * has been re-instantiated with the saved values.
        * We use the last `isFormDirty` value instead of `dirty`.
        */
-      return (activeMissionId && selectedMissions[activeMissionId]?.isFormDirty) || false
+      return activeMission?.isFormDirty ?? false
     }
 
     return !isEmpty(errors)

--- a/frontend/src/features/missions/MissionForm/slice.ts
+++ b/frontend/src/features/missions/MissionForm/slice.ts
@@ -48,6 +48,19 @@ const missionFormsSlice = createSlice({
     setActiveMissionId(state, action: PayloadAction<number | string>) {
       state.activeMissionId = action.payload
     },
+    setCreatedMission(state, action: PayloadAction<{ createdMission: MissionInStateType; newId: string }>) {
+      const { newId } = action.payload
+      const createdMissionId = action.payload.createdMission.missionForm.id
+      if (!newId || !createdMissionId) {
+        return
+      }
+      const mission = state.missions[newId]
+      if (mission) {
+        delete state.missions[newId]
+        state.missions = { ...state.missions, [createdMissionId]: action.payload.createdMission }
+      }
+      state.activeMissionId = createdMissionId
+    },
     setEngagedControlUnit(state, action: PayloadAction<ControlUnit.EngagedControlUnit | undefined>) {
       const { activeMissionId } = state
 

--- a/frontend/src/features/missions/MissionForm/slice.ts
+++ b/frontend/src/features/missions/MissionForm/slice.ts
@@ -48,15 +48,15 @@ const missionFormsSlice = createSlice({
     setActiveMissionId(state, action: PayloadAction<number | string>) {
       state.activeMissionId = action.payload
     },
-    setCreatedMission(state, action: PayloadAction<{ createdMission: MissionInStateType; newId: string }>) {
-      const { newId } = action.payload
+    setCreatedMission(state, action: PayloadAction<{ createdMission: MissionInStateType; previousId: string }>) {
+      const { previousId } = action.payload
       const createdMissionId = action.payload.createdMission.missionForm.id
-      if (!newId || !createdMissionId) {
+      if (!previousId || !createdMissionId) {
         return
       }
-      const mission = state.missions[newId]
-      if (mission) {
-        delete state.missions[newId]
+      const missionWithPreviousId = state.missions[previousId]
+      if (missionWithPreviousId) {
+        delete state.missions[previousId]
         state.missions = { ...state.missions, [createdMissionId]: action.payload.createdMission }
       }
       state.activeMissionId = createdMissionId


### PR DESCRIPTION
J'ai créée une nouvelle action spécifique pour la création de mission. Elle vient supprimer la mission dans le store avec l'id `new-xxx` et restocker la mission à jour (avec le bon id) dans le store.
J'ai également diminuer le délai du callback ici :  useSyncFormValuesWithRedux.ts, qui, je pense, était trop long et posait des soucis de mise à jour de données (notamment avec le nouvel id)

## Related Pull Requests & Issues

- Resolve #1292

----

- [ ] Tests E2E (Cypress)
