### PR TITLE
[Carte] Résolution du bug au zoom sur la carte

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/mission_actions.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/mission_actions.spec.ts
@@ -418,7 +418,7 @@ context('Side Window > Mission Form > Mission actions', () => {
   it("Should display warning toast if fish api doesn't respond", () => {
     cy.fill('Période', 'Un mois')
     cy.wait(500)
-    cy.getDataCy('edit-mission-27').click({ force: true }).scrollIntoView()
+    cy.getDataCy('edit-mission-27').scrollIntoView().click({ force: true })
     cy.get('.Toastify__toast-body').contains(
       'Problème de communication avec MonitorFish: impossible de récupérer les actions du CNSP'
     )

--- a/frontend/src/features/map/ZoomListener.tsx
+++ b/frontend/src/features/map/ZoomListener.tsx
@@ -1,0 +1,35 @@
+import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { removeAllOverlayCoordinates } from 'domain/shared_slices/Global'
+import { isEmpty } from 'lodash'
+import { useEffect } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
+
+type ZoomListenerProps = {
+  map?: any
+}
+
+export function ZoomListener({ map }: ZoomListenerProps) {
+  const dispatch = useAppDispatch()
+
+  const overlayCoordinates = useAppSelector(state => state.global.overlayCoordinates)
+
+  const debouncedHandleChangeResolution = useDebouncedCallback(() => {
+    if (!isEmpty(overlayCoordinates)) {
+      dispatch(removeAllOverlayCoordinates())
+    }
+  }, 250)
+
+  useEffect(() => {
+    if (!map) {
+      return
+    }
+
+    const view = map.getView()
+    view.on('change:resolution', () => {
+      debouncedHandleChangeResolution()
+    })
+  }, [map, debouncedHandleChangeResolution])
+
+  return null
+}

--- a/frontend/src/features/map/ZoomListener.tsx
+++ b/frontend/src/features/map/ZoomListener.tsx
@@ -5,11 +5,9 @@ import { isEmpty } from 'lodash'
 import { useEffect } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
-type ZoomListenerProps = {
-  map?: any
-}
+import type { BaseMapChildrenProps } from './BaseMap'
 
-export function ZoomListener({ map }: ZoomListenerProps) {
+export function ZoomListener({ map }: BaseMapChildrenProps) {
   const dispatch = useAppDispatch()
 
   const overlayCoordinates = useAppSelector(state => state.global.overlayCoordinates)

--- a/frontend/src/features/map/index.tsx
+++ b/frontend/src/features/map/index.tsx
@@ -26,6 +26,7 @@ import { MissionOverlays } from './overlays/missions'
 import { ReportingOverlay } from './overlays/reportings'
 import { SemaphoreOverlay } from './overlays/semaphores'
 import { ShowRegulatoryMetadata } from './ShowRegulatoryMetadata'
+import { ZoomListener } from './ZoomListener'
 import { ReportingToAttachLayer } from '../missions/Layers/ReportingToAttach'
 import { HoveredReportingToAttachLayer } from '../missions/Layers/ReportingToAttach/HoveredReportingToAttachLayer'
 import { ReportingToAttachOverlays } from '../missions/Overlays/ReportingToAttach'
@@ -47,6 +48,8 @@ export function Map() {
     //
     // -> only add child to BaseMap if it requires map or mapClickEvent
     >
+      {/* @ts-ignore */}
+      <ZoomListener />
       {/* @ts-ignore */}
       <MapAttributionsBox />
       {/* @ts-ignore */}

--- a/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
+++ b/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
@@ -92,21 +92,21 @@ export function OverlayPositionOnCentroid({
     }
   }, [feature])
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedHandleChangeResolution = useCallback(
-    debounce(() => {
-      if (overlayCoordinates) {
-        dispatch(removeAllOverlayCoordinates())
-      }
-    }, 500),
-    []
+    newOverlayCoordinates =>
+      debounce(() => {
+        if (newOverlayCoordinates) {
+          dispatch(removeAllOverlayCoordinates())
+        }
+      }, 500),
+    [dispatch]
   )
 
   useEffect(() => {
     const view = map.getView()
 
     view.on('change:resolution', () => {
-      debouncedHandleChangeResolution()
+      debouncedHandleChangeResolution(overlayCoordinates)
     })
   }, [dispatch, map, overlayCoordinates, debouncedHandleChangeResolution])
 

--- a/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
+++ b/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
@@ -1,14 +1,12 @@
 // @ts-nocheck
-import { debounce } from 'lodash'
 import { getCenter } from 'ol/extent'
 import Overlay from 'ol/Overlay'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { getOverlayPositionForCentroid, getTopLeftMargin } from './position'
-import { removeAllOverlayCoordinates, setOverlayCoordinatesByName } from '../../../domain/shared_slices/Global'
+import { setOverlayCoordinatesByName } from '../../../domain/shared_slices/Global'
 import { useAppDispatch } from '../../../hooks/useAppDispatch'
-import { useAppSelector } from '../../../hooks/useAppSelector'
 import { useMoveOverlayWhenDragging } from '../../../hooks/useMoveOverlayWhenDragging'
 
 import type { Feature } from 'ol'
@@ -59,7 +57,6 @@ export function OverlayPositionOnCentroid({
   const isThrottled = useRef(false)
   const [showed, setShowed] = useState(false)
   const currentCoordinates = useRef([])
-  const overlayCoordinates = useAppSelector(state => state.global.overlayCoordinates)
 
   const [overlayTopLeftMargin, setOverlayTopLeftMargin] = useState([margins.yBottom, margins.xMiddle])
   const currentOffset = useRef(INITIAL_OFFSET_VALUE)
@@ -91,24 +88,6 @@ export function OverlayPositionOnCentroid({
       currentCoordinates.current = undefined
     }
   }, [feature])
-
-  const debouncedHandleChangeResolution = useCallback(
-    newOverlayCoordinates =>
-      debounce(() => {
-        if (newOverlayCoordinates) {
-          dispatch(removeAllOverlayCoordinates())
-        }
-      }, 500),
-    [dispatch]
-  )
-
-  useEffect(() => {
-    const view = map.getView()
-
-    view.on('change:resolution', () => {
-      debouncedHandleChangeResolution(overlayCoordinates)
-    })
-  }, [dispatch, map, overlayCoordinates, debouncedHandleChangeResolution])
 
   useEffect(() => {
     if (map) {

--- a/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
+++ b/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// import { debounce } from 'lodash'
+import { debounce } from 'lodash'
 import { getCenter } from 'ol/extent'
 import Overlay from 'ol/Overlay'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -93,24 +93,22 @@ export function OverlayPositionOnCentroid({
   }, [feature])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  /*   const debouncedHandleChangeResolution = useCallback(
+  const debouncedHandleChangeResolution = useCallback(
     debounce(() => {
       if (overlayCoordinates) {
         dispatch(removeAllOverlayCoordinates())
       }
     }, 500),
-    [overlayCoordinates, dispatch]
-  ) */
+    []
+  )
 
   useEffect(() => {
     const view = map.getView()
 
     view.on('change:resolution', () => {
-      if (overlayCoordinates) {
-        dispatch(removeAllOverlayCoordinates())
-      }
+      debouncedHandleChangeResolution()
     })
-  }, [dispatch, map, overlayCoordinates])
+  }, [dispatch, map, overlayCoordinates, debouncedHandleChangeResolution])
 
   useEffect(() => {
     if (map) {

--- a/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
+++ b/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { debounce } from 'lodash'
+// import { debounce } from 'lodash'
 import { getCenter } from 'ol/extent'
 import Overlay from 'ol/Overlay'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -93,22 +93,24 @@ export function OverlayPositionOnCentroid({
   }, [feature])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedHandleChangeResolution = useCallback(
+  /*   const debouncedHandleChangeResolution = useCallback(
     debounce(() => {
       if (overlayCoordinates) {
         dispatch(removeAllOverlayCoordinates())
       }
     }, 500),
     [overlayCoordinates, dispatch]
-  )
+  ) */
 
   useEffect(() => {
     const view = map.getView()
 
     view.on('change:resolution', () => {
-      debouncedHandleChangeResolution()
+      if (overlayCoordinates) {
+        dispatch(removeAllOverlayCoordinates())
+      }
     })
-  }, [dispatch, map, overlayCoordinates, debouncedHandleChangeResolution])
+  }, [dispatch, map, overlayCoordinates])
 
   useEffect(() => {
     if (map) {


### PR DESCRIPTION
J'ai supprimé les dépendances dans le usecallback appelé lors du zoom sur la carte. Cela faisait laguer le zoom et l'appli était comme "bloquée"

Bug introduit dans cette PR : https://github.com/MTES-MCT/monitorenv/pull/1260


----

- [ ] Tests E2E (Cypress)
