### PR TITLE
[Surveillance] Ajout des boutons de "type" de zone pour dessiner la zone de surveillance

### DIFF
--- a/frontend/src/features/map/draw/DrawModal.tsx
+++ b/frontend/src/features/map/draw/DrawModal.tsx
@@ -167,7 +167,9 @@ export function DrawModal() {
   return (
     <MapInteraction
       customTools={
-        (listener === InteractionListener.MISSION_ZONE || listener === InteractionListener.REPORTING_ZONE) && (
+        (listener === InteractionListener.MISSION_ZONE ||
+          listener === InteractionListener.REPORTING_ZONE ||
+          listener === InteractionListener.SURVEILLANCE_ZONE) && (
           <IconGroup>
             <IconButton
               className={interactionType === InteractionType.POLYGON ? '_active' : undefined}


### PR DESCRIPTION
Ajout des boutons des types de zone dans la modal pour dessiner la zone de surveillance

## Related Pull Requests & Issues

- Resolve #1313


----

- [ ] Tests E2E (Cypress)
