### PR TITLE
[Mission] Résolution du bug de l'api /missions qui renvoyait les missions Poseidon

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IMissionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IMissionRepository.kt
@@ -17,6 +17,7 @@ interface IMissionRepository {
 
     fun findAllFullMissions(
         controlUnitIds: List<Int>? = null,
+        missionSources: List<MissionSourceEnum>? = null,
         missionStatuses: List<String>?,
         missionTypes: List<MissionTypeEnum>?,
         pageNumber: Int?,

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/GetFullMissions.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/GetFullMissions.kt
@@ -3,6 +3,7 @@
 package fr.gouv.cacem.monitorenv.domain.use_cases.missions
 
 import fr.gouv.cacem.monitorenv.config.UseCase
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionSourceEnum
 import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionTypeEnum
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
 import fr.gouv.cacem.monitorenv.domain.repositories.IMonitorFishMissionActionsRepository
@@ -30,6 +31,11 @@ class GetFullMissions(
                 startedAfter = startedAfterDateTime?.toInstant()
                     ?: ZonedDateTime.now().minusDays(30).toInstant(),
                 startedBefore = startedBeforeDateTime?.toInstant(),
+                missionSources =
+                listOf(
+                    MissionSourceEnum.MONITORENV,
+                    MissionSourceEnum.MONITORFISH,
+                ),
                 missionTypes = missionTypes,
                 missionStatuses = missionStatuses,
                 seaFronts = seaFronts,

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaMissionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaMissionRepository.kt
@@ -39,6 +39,7 @@ class JpaMissionRepository(
     @Transactional
     override fun findAllFullMissions(
         controlUnitIds: List<Int>?,
+        missionSources: List<MissionSourceEnum>?,
         missionStatuses: List<String>?,
         missionTypes: List<MissionTypeEnum>?,
         pageNumber: Int?,
@@ -59,7 +60,7 @@ class JpaMissionRepository(
             missionTypeAIR = MissionTypeEnum.AIR in missionTypes.orEmpty(),
             missionTypeLAND = MissionTypeEnum.LAND in missionTypes.orEmpty(),
             missionTypeSEA = MissionTypeEnum.SEA in missionTypes.orEmpty(),
-            missionSources = null,
+            missionSources = missionSources,
             pageable = pageable,
             seaFronts = seaFronts,
             startedAfter = startedAfter,


### PR DESCRIPTION
En supprimant le filtre `missionSources` on récupérait les missions historiques de Poseidon