### PR TITLE
[Mission] Le trigramme "complété par" des actions n'est plus obligatoire

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/mission_actions.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/mission_actions.spec.ts
@@ -328,7 +328,7 @@ context('Side Window > Mission Form > Mission actions', () => {
     cy.clickButton('Ajouter')
     cy.clickButton('Ajouter une surveillance')
 
-    cy.getDataCy('action-missing-fields-text').contains('4 champs nécessaires aux statistiques à compléter')
+    cy.getDataCy('action-missing-fields-text').contains('3 champs nécessaires aux statistiques à compléter')
 
     cy.get('*[data-cy="envaction-theme-selector"]').eq(0).click({ force: true })
     cy.get('*[data-cy="envaction-theme-element"]').eq(0).contains('Épave').click({ force: true }) // id 105
@@ -348,7 +348,7 @@ context('Side Window > Mission Form > Mission actions', () => {
     // Add a control
     cy.clickButton('Ajouter')
     cy.clickButton('Ajouter des contrôles')
-    cy.getDataCy('action-missing-fields-text').contains('8 champs nécessaires aux statistiques à compléter')
+    cy.getDataCy('action-missing-fields-text').contains('7 champs nécessaires aux statistiques à compléter')
 
     cy.intercept('PUT', '/bff/v1/missions/*').as('updateMission')
 
@@ -400,6 +400,11 @@ context('Side Window > Mission Form > Mission actions', () => {
       cy.wait(250)
       cy.get('*[data-cy="action-card"]').eq(1).click()
       cy.getDataCy('action-missing-fields-text').contains('2 champs nécessaires aux statistiques à compléter')
+
+      // delete created mission
+      cy.clickButton('Supprimer la mission')
+      cy.wait(400)
+      cy.get('*[name="delete-mission-modal-confirm"]').click()
     })
   })
 

--- a/frontend/src/domain/use_cases/missions/saveMission.ts
+++ b/frontend/src/domain/use_cases/missions/saveMission.ts
@@ -22,7 +22,8 @@ export const saveMission =
     } = getState()
     const selectedMissions = getState().missionForms.missions
 
-    const sortedActions = values.envActions.sort((a, b) => a.id - b.id)
+    const envActions = [...values.envActions]
+    const sortedActions = envActions.sort((a, b) => a.id - b.id)
     const valuesToSave = omit({ ...values, envActions: sortedActions }, [
       'attachedReportings',
       'detachedReportings',

--- a/frontend/src/features/missions/MissionForm/Schemas/Control.ts
+++ b/frontend/src/features/missions/MissionForm/Schemas/Control.ts
@@ -92,8 +92,7 @@ export const getCompletionEnvActionControlSchema = (ctx: any): Yup.SchemaOf<EnvA
       completedBy: Yup.string()
         .min(3, 'Minimum 3 lettres pour le trigramme')
         .max(3, 'Maximum 3 lettres pour le trigramme')
-        .nullable()
-        .required(HIDDEN_ERROR),
+        .nullable(),
       controlPlans: Yup.array().of(ClosedControlPlansSchema).ensure().required().min(1),
       geom: shouldUseAlternateValidationInTestEnvironment
         ? Yup.object().nullable()

--- a/frontend/src/features/missions/MissionForm/Schemas/Surveillance.ts
+++ b/frontend/src/features/missions/MissionForm/Schemas/Surveillance.ts
@@ -143,8 +143,7 @@ export const getCompletionEnvActionSurveillanceSchema = (ctx: any): Yup.SchemaOf
       completedBy: Yup.string()
         .min(3, 'Minimum 3 lettres pour le trigramme')
         .max(3, 'Maximum 3 lettres pour le trigramme')
-        .nullable()
-        .required(HIDDEN_ERROR),
+        .nullable(),
       controlPlans: Yup.array().ensure().of(ClosedControlPlansSchema).ensure().required().min(1),
       geom: shouldUseAlternateValidationInTestEnvironment
         ? Yup.object().nullable()


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #1344


----

- [ ] Tests E2E (Cypress)
