### PR TITLE
[Contrôle] Mettre à jour les informations d'un contrôle lorsqu'on change le signalement rattaché à cette action

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/attach_actions_to_reportings_in_mission.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/attach_actions_to_reportings_in_mission.spec.ts
@@ -188,6 +188,8 @@ context('Side Window > Mission Form > Attach action to reporting', () => {
         cy.clickButton('Editer')
         cy.getDataCy('infraction-form').should('be.visible')
 
+        cy.get('*[data-cy="envaction-theme-selector"]').contains('Rejet')
+        cy.get('*[data-cy="envaction-theme-element"]').contains('Carénage sauvage')
         cy.getDataCy('infraction-form-registrationNumber').should('have.value', '123456789')
         cy.getDataCy('infraction-form-controlledPersonIdentity').should('have.value', 'Le Bateau 2000')
         cy.getDataCy('infraction-form-vessel-size').should('have.value', 13)
@@ -223,6 +225,8 @@ context('Side Window > Mission Form > Attach action to reporting', () => {
             const formattedReportingId = getFormattedReportingId(firstReporting.reportingId)
             cy.fill('Signalements', formattedReportingId)
 
+            cy.get('*[data-cy="envaction-theme-selector"]').contains('Culture marine')
+            cy.get('*[data-cy="envaction-theme-element"]').contains('Remise en état après occupation du DPM')
             cy.getDataCy('infraction-form-registrationNumber').should('have.value', '987654321')
             cy.getDataCy('infraction-form-controlledPersonIdentity').should('have.value', 'The Boat')
             cy.get('.Field-MultiRadio').contains("Type d'infraction").get('[aria-checked="true"]').contains('Avec PV')

--- a/frontend/cypress/e2e/utils/createReportingOnSideWindow.ts
+++ b/frontend/cypress/e2e/utils/createReportingOnSideWindow.ts
@@ -1,0 +1,45 @@
+import { setGeometry } from 'domain/shared_slices/Draw'
+
+import type { GeoJSON } from 'domain/types/GeoJSON'
+
+const dispatch = action => cy.window().its('store').invoke('dispatch', action)
+
+export function createReportingOnSideWindow() {
+  cy.clickButton('signalements')
+  cy.clickButton('Ajouter un nouveau signalement')
+  cy.intercept('PUT', '/bff/v1/reportings').as('createReporting')
+  cy.wait(500)
+
+  // When
+  cy.get('div').contains('Signalement non créé')
+  cy.fill('Nom du Sémaphore', 'Sémaphore de Dieppe')
+
+  cy.getDataCy('reporting-target-type').click({ force: true })
+  cy.get('div[role="option"]').contains('Véhicule').click()
+
+  cy.fill('Type de véhicule', 'Navire')
+  cy.fill('Nom du navire', 'The Boat')
+  cy.fill('Immatriculation', '987654321')
+  cy.fill('Taille', 54)
+
+  cy.clickButton('Ajouter un point')
+
+  const geometry: GeoJSON.Geometry = {
+    coordinates: [[-16.12054383, 49.94264815]],
+    type: 'MultiPoint'
+  }
+
+  dispatch(setGeometry(geometry))
+
+  cy.get('.rs-radio').find('label').contains('Infraction (susp.)').click()
+  cy.fill('Thématique du signalement', 'Culture marine')
+  cy.fill('Sous-thématique du signalement', ['Remise en état après occupation du DPM'])
+  cy.wait(250)
+  cy.fill('Saisi par', 'XYZ')
+
+  return cy.wait('@createReporting').then(({ response }) => {
+    cy.clickButton('Fermer')
+
+    return Promise.resolve(response)
+  })
+}

--- a/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/InfractionForm/InfractionForm.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/InfractionForm/InfractionForm.tsx
@@ -12,7 +12,7 @@ import { TargetTypeEnum } from '../../../../../../domain/entities/targetType'
 import type { MouseEventHandler } from 'react'
 
 const infractionTypeOptions = Object.values(infractionTypeLabels).map(o => ({ label: o.libelle, value: o.code }))
-const formalNoticeOPtions = Object.values(formalNoticeLabels).map(o => ({ label: o.libelle, value: o.code }))
+const formalNoticeOptions = Object.values(formalNoticeLabels).map(o => ({ label: o.libelle, value: o.code }))
 
 type InfractionFormProps = {
   currentInfractionIndex: number
@@ -61,7 +61,7 @@ export function InfractionForm({
         isRequired
         label="Mise en demeure"
         name={`${infractionPath}.formalNotice`}
-        options={formalNoticeOPtions}
+        options={formalNoticeOptions}
       />
 
       <NatinfSelector infractionPath={infractionPath} />

--- a/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/index.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/index.tsx
@@ -33,7 +33,7 @@ import {
   ActionTypeEnum,
   CompletionStatus
 } from '../../../../../domain/entities/missions'
-import { TargetTypeEnum, TargetTypeLabels } from '../../../../../domain/entities/targetType'
+import { ReportingTargetTypeEnum, TargetTypeEnum, TargetTypeLabels } from '../../../../../domain/entities/targetType'
 import { VehicleTypeEnum } from '../../../../../domain/entities/vehicleType'
 import { TargetSelector } from '../../../../commonComponents/TargetSelector'
 import { VehicleTypeSelector } from '../../../../commonComponents/VehicleTypeSelector'
@@ -199,17 +199,63 @@ export function ControlForm({
       return
     }
     setFieldValue(`envActions[${envActionIndex}].reportingIds`, [reportingId])
-    const reportingToAttachIndex = attachedReportings?.findIndex(reporting => reporting.id === reportingId)
-
-    if (reportingToAttachIndex !== -1) {
-      setFieldValue(`attachedReportings[${reportingToAttachIndex}].attachedEnvActionId`, currentAction?.id)
-    }
 
     const reportingToDetachIndex = attachedReportings?.findIndex(
       reporting => reporting.attachedEnvActionId === currentAction?.id && reporting.id !== reportingId
     )
     if (reportingToDetachIndex !== -1) {
       setFieldValue(`attachedReportings[${reportingToDetachIndex}].attachedEnvActionId`, undefined)
+    }
+
+    const reportingToAttachIndex = attachedReportings?.findIndex(reporting => reporting.id === reportingId)
+    if (reportingToAttachIndex !== -1) {
+      setFieldValue(`attachedReportings[${reportingToAttachIndex}].attachedEnvActionId`, currentAction?.id)
+
+      // prefill infractions with the reporting details
+      const reporting = attachedReportings[reportingToAttachIndex]
+      if (
+        reporting &&
+        reporting.targetType !== ReportingTargetTypeEnum.OTHER &&
+        reporting.targetDetails &&
+        reporting.targetDetails.length > 0
+      ) {
+        const updatedInfractions = reporting.targetDetails.map(target => {
+          switch (reporting.targetType) {
+            case ReportingTargetTypeEnum.VEHICLE:
+              return {
+                controlledPersonIdentity: target?.vesselName ?? target?.operatorName,
+                registrationNumber: target?.externalReferenceNumber,
+                ...(reporting.vehicleType === VehicleTypeEnum.VESSEL && {
+                  vesselSize: target?.size
+                })
+              }
+
+            case ReportingTargetTypeEnum.COMPANY:
+              return {
+                companyName: target?.operatorName,
+                controlledPersonIdentity: target?.vesselName
+              }
+
+            default:
+              return {
+                controlledPersonIdentity: target?.operatorName
+              }
+          }
+        })
+
+        if (currentAction?.infractions?.length === 1) {
+          setFieldValue(`envActions[${envActionIndex}].infractions[0]`, {
+            ...currentAction.infractions[0],
+            ...updatedInfractions[0]
+          })
+
+          return
+        }
+
+        if (currentAction?.infractions?.length && currentAction?.infractions?.length > 1) {
+          setFieldValue(`envActions[${envActionIndex}].infractions`, updatedInfractions)
+        }
+      }
     }
   }
 

--- a/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/index.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/index.tsx
@@ -210,9 +210,12 @@ export function ControlForm({
     const reportingToAttachIndex = attachedReportings?.findIndex(reporting => reporting.id === reportingId)
     if (reportingToAttachIndex !== -1) {
       setFieldValue(`attachedReportings[${reportingToAttachIndex}].attachedEnvActionId`, currentAction?.id)
-
       // prefill infractions with the reporting details
       const reporting = attachedReportings[reportingToAttachIndex]
+      setFieldValue(`envActions[${envActionIndex}].controlPlans`, [
+        { subThemeIds: reporting?.subThemeIds, tagIds: [], themeId: reporting?.themeId }
+      ])
+
       if (
         reporting &&
         reporting.targetType !== ReportingTargetTypeEnum.OTHER &&

--- a/frontend/src/features/missions/MissionForm/Schemas/Control.ts
+++ b/frontend/src/features/missions/MissionForm/Schemas/Control.ts
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import * as Yup from 'yup'
 
 import { ClosedControlPlansSchema } from './ControlPlans'
-import { ClosedInfractionSchema, NewInfractionSchema } from './Infraction'
+import { CompletionInfractionSchema, NewInfractionSchema } from './Infraction'
 import { ActionTypeEnum, type EnvActionControl } from '../../../../domain/entities/missions'
 import { TargetTypeEnum } from '../../../../domain/entities/targetType'
 import { isCypress } from '../../../../utils/isCypress'
@@ -98,7 +98,7 @@ export const getCompletionEnvActionControlSchema = (ctx: any): Yup.SchemaOf<EnvA
         ? Yup.object().nullable()
         : Yup.array().of(ControlPointSchema).ensure().min(1, 'Point de contrôle requis'),
       id: Yup.string().required(),
-      infractions: Yup.array().of(ClosedInfractionSchema).ensure().required(),
+      infractions: Yup.array().of(CompletionInfractionSchema).ensure().required(),
       openBy: Yup.string()
         .min(3, 'Minimum 3 lettres pour le trigramme')
         .max(3, 'Maximum 3 lettres pour le trigramme')

--- a/frontend/src/features/missions/MissionForm/Schemas/Infraction.ts
+++ b/frontend/src/features/missions/MissionForm/Schemas/Infraction.ts
@@ -43,7 +43,7 @@ export const NewInfractionSchema: Yup.SchemaOf<Infraction> = Yup.object().shape(
   vesselType: Yup.mixed().oneOfOptional(Object.values(VesselTypeEnum))
 })
 
-export const ClosedInfractionSchema: Yup.SchemaOf<Infraction> = NewInfractionSchema.shape({
+export const CompletionInfractionSchema: Yup.SchemaOf<Infraction> = NewInfractionSchema.shape({
   formalNotice: Yup.mixed().oneOf([FormalNoticeEnum.YES, FormalNoticeEnum.NO]).required(),
   infractionType: Yup.mixed().oneOf([InfractionTypeEnum.WITH_REPORT, InfractionTypeEnum.WITHOUT_REPORT]).required()
 })


### PR DESCRIPTION
Modifier les informations d'un contrôle (thématiques, sous-thématiques, et données de la cible de l'infraction) lorsque l'utilisateur avait rattaché le contrôle à un signalement et qu'il change le signalement rattaché au contrôle.


## Related Pull Requests & Issues

- Resolve #1381

----

- [x] Tests E2E (Cypress)
