### PR TITLE
[Unité de contrôle] La modal d'édition d'une unité s'adapte en hauteur au contenu

### DIFF
--- a/frontend/src/features/ControlUnit/components/ControlUnitDialog/index.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitDialog/index.tsx
@@ -80,7 +80,8 @@ const Wrapper = styled(MapMenuDialog.Container)<{
   bottom: 0;
   /* TODO Remove margin in monitor-ui. */
   margin: 0;
-  max-height: none;
+  max-height: 100%;
+  height: fit-content;
   position: absolute;
   right: ${p => (p.$isRightMenuOpened ? 56 : 8)}px;
   top: 0;

--- a/frontend/src/features/Station/components/StationLayer/utils.ts
+++ b/frontend/src/features/Station/components/StationLayer/utils.ts
@@ -38,7 +38,7 @@ export const getFeatureStyle = ((feature: Feature) => {
       fill: new Fill({
         color: THEME.color.white
       }),
-      font: `11px 'Open Sans'`,
+      font: `700 11px 'Open Sans'`,
       offsetX: 16.5,
       offsetY: -35.5,
       text: featureProps.controlUnitsCount.toString(),


### PR DESCRIPTION
- La hauteur de la modal s'adapte maintenant au contenu
## Related Pull Requests & Issues

- Resolve #1105

----

- [ ] Tests E2E (Cypress)
