### PR TITLE
[BackOffice] Résolution du souci d'affichage des tableaux dans le backoffice

### DIFF
--- a/frontend/src/features/Administration/components/AdministrationForm/constants.tsx
+++ b/frontend/src/features/Administration/components/AdministrationForm/constants.tsx
@@ -22,7 +22,8 @@ export const CONTROL_UNIT_TABLE_COLUMNS: Array<ColumnDef<ControlUnit.ControlUnit
   {
     accessorFn: row => row.name,
     header: () => 'Nom',
-    id: 'name'
+    id: 'name',
+    size: 400
   },
   {
     accessorFn: row => row.id,

--- a/frontend/src/features/ControlUnit/components/ControlUnitForm/constants.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitForm/constants.tsx
@@ -15,7 +15,8 @@ export const CONTROL_UNIT_CONTACT_TABLE_COLUMNS: Array<ColumnDef<ControlUnit.Con
   {
     accessorFn: row => row.name,
     header: () => 'Nom',
-    id: 'name'
+    id: 'name',
+    size: 400
   }
 ]
 
@@ -30,7 +31,8 @@ export const CONTROL_UNIT_RESOURCE_TABLE_COLUMNS: Array<ColumnDef<ControlUnit.Co
   {
     accessorFn: row => row.name,
     header: () => 'Nom',
-    id: 'name'
+    id: 'name',
+    size: 400
   }
 ]
 

--- a/frontend/src/features/Reportings/Filters/Table/index.tsx
+++ b/frontend/src/features/Reportings/Filters/Table/index.tsx
@@ -1,4 +1,12 @@
-import { CheckPicker, DateRangePicker, Checkbox, Icon, CustomSearch, type Option } from '@mtes-mct/monitor-ui'
+import {
+  CheckPicker,
+  DateRangePicker,
+  Checkbox,
+  Icon,
+  CustomSearch,
+  type Option,
+  useNewWindow
+} from '@mtes-mct/monitor-ui'
 import { forwardRef, useMemo } from 'react'
 import styled from 'styled-components'
 
@@ -31,6 +39,7 @@ export function TableReportingsFiltersWithRef(
   },
   ref
 ) {
+  const { newWindowContainerRef } = useNewWindow()
   const {
     hasFilters,
     isAttachedToMissionFilter,
@@ -252,6 +261,7 @@ export function TableReportingsFiltersWithRef(
             <StyledCutomPeriodLabel>Période spécifique</StyledCutomPeriodLabel>
             <DateRangePicker
               key="dateRange"
+              baseContainer={newWindowContainerRef.current}
               data-cy="datepicker-missionStartedAfter"
               defaultValue={
                 startedAfter && startedBefore ? [new Date(startedAfter), new Date(startedBefore)] : undefined

--- a/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
@@ -1,11 +1,19 @@
 import { getTimeLeft } from '@features/Reportings/utils'
-import { FormikDatePicker, FormikNumberInput, customDayjs, getLocalizedDayjs } from '@mtes-mct/monitor-ui'
+import { FormikDatePicker, FormikNumberInput, customDayjs, getLocalizedDayjs, useNewWindow } from '@mtes-mct/monitor-ui'
 import { ReportingStatusEnum, type Reporting, getReportingStatus } from 'domain/entities/reporting'
+import { ReportingContext } from 'domain/shared_slices/Global'
 import { useFormikContext } from 'formik'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import styled from 'styled-components'
 
-export function Validity({ mustIncreaseValidity }: { mustIncreaseValidity: boolean }) {
+type ValidityProps = {
+  mustIncreaseValidity: boolean
+  reportingContext: ReportingContext
+}
+export function Validity({ mustIncreaseValidity, reportingContext }: ValidityProps) {
+  const { newWindowContainerRef } = useNewWindow()
+  const mapRef = useRef<HTMLDivElement>(null)
+
   const { values } = useFormikContext<Reporting>()
 
   const reportingStatus = getReportingStatus(values)
@@ -30,6 +38,7 @@ export function Validity({ mustIncreaseValidity }: { mustIncreaseValidity: boole
     <StyledValidityContainer>
       <div>
         <FormikDatePicker
+          baseContainer={reportingContext === ReportingContext.MAP ? mapRef.current : newWindowContainerRef.current}
           isCompact
           isErrorMessageHidden
           isHistorical

--- a/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
@@ -3,7 +3,7 @@ import { FormikDatePicker, FormikNumberInput, customDayjs, getLocalizedDayjs, us
 import { ReportingStatusEnum, type Reporting, getReportingStatus } from 'domain/entities/reporting'
 import { ReportingContext } from 'domain/shared_slices/Global'
 import { useFormikContext } from 'formik'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import styled from 'styled-components'
 
 type ValidityProps = {
@@ -12,7 +12,6 @@ type ValidityProps = {
 }
 export function Validity({ mustIncreaseValidity, reportingContext }: ValidityProps) {
   const { newWindowContainerRef } = useNewWindow()
-  const mapRef = useRef<HTMLDivElement>(null)
 
   const { values } = useFormikContext<Reporting>()
 
@@ -38,7 +37,7 @@ export function Validity({ mustIncreaseValidity, reportingContext }: ValidityPro
     <StyledValidityContainer>
       <div>
         <FormikDatePicker
-          baseContainer={reportingContext === ReportingContext.MAP ? mapRef.current : newWindowContainerRef.current}
+          baseContainer={reportingContext === ReportingContext.SIDE_WINDOW ? newWindowContainerRef.current : undefined}
           isCompact
           isErrorMessageHidden
           isHistorical

--- a/frontend/src/features/Reportings/components/ReportingForm/FormContent.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/FormContent.tsx
@@ -356,7 +356,7 @@ export function FormContent({ reducedReportingsOnContext, selectedReporting }: F
           )}
         </StyledThemeContainer>
 
-        <Validity mustIncreaseValidity={mustIncreaseValidity} />
+        <Validity mustIncreaseValidity={mustIncreaseValidity} reportingContext={reportingContext} />
 
         <StyledFormikTextInput isErrorMessageHidden isRequired label="Saisi par" name="openBy" />
 

--- a/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/index.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/ControlForm/index.tsx
@@ -16,7 +16,8 @@ import {
   Toggle,
   pluralize,
   Button,
-  FormikTextInput
+  FormikTextInput,
+  useNewWindow
 } from '@mtes-mct/monitor-ui'
 import { FieldArray, useFormikContext, type FormikErrors } from 'formik'
 import _ from 'lodash'
@@ -63,6 +64,7 @@ export function ControlForm({
   removeControlAction: () => void
   setCurrentActionIndex: (string) => void
 }) {
+  const { newWindowContainerRef } = useNewWindow()
   const {
     errors,
     setFieldValue,
@@ -360,6 +362,7 @@ export function ControlForm({
 
         <div>
           <DatePicker
+            baseContainer={newWindowContainerRef.current}
             defaultValue={currentAction?.actionStartDateTimeUtc ?? undefined}
             error={currentActionErrors?.actionStartDateTimeUtc ?? undefined}
             isErrorMessageHidden

--- a/frontend/src/features/missions/MissionForm/ActionForm/SurveillanceForm/index.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionForm/SurveillanceForm/index.tsx
@@ -16,7 +16,8 @@ import {
   Label,
   Toggle,
   Button,
-  FormikTextInput
+  FormikTextInput,
+  useNewWindow
 } from '@mtes-mct/monitor-ui'
 import { useField, useFormikContext, type FormikErrors } from 'formik'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -50,6 +51,8 @@ import {
 import { SurveillanceThemes } from '../Themes/SurveillanceThemes'
 
 export function SurveillanceForm({ currentActionIndex, remove, setCurrentActionIndex }) {
+  const { newWindowContainerRef } = useNewWindow()
+
   const {
     errors,
     setFieldValue,
@@ -240,6 +243,7 @@ export function SurveillanceForm({ currentActionIndex, remove, setCurrentActionI
           <StyledDatePickerContainer>
             <StyledDatePicker
               key={`start-date-${durationMatchMissionField.value}`}
+              baseContainer={newWindowContainerRef.current}
               data-cy="surveillance-start-date-time"
               defaultValue={currentAction?.actionStartDateTimeUtc ?? undefined}
               disabled={!!durationMatchMissionField.value}
@@ -257,6 +261,7 @@ export function SurveillanceForm({ currentActionIndex, remove, setCurrentActionI
             />
             <StyledDatePicker
               key={`end-date-${durationMatchMissionField.value}`}
+              baseContainer={newWindowContainerRef.current}
               data-cy="surveillance-end-date-time"
               defaultValue={currentAction?.actionEndDateTimeUtc ?? undefined}
               disabled={!!durationMatchMissionField.value}

--- a/frontend/src/features/missions/MissionForm/GeneralInformationsForm.tsx
+++ b/frontend/src/features/missions/MissionForm/GeneralInformationsForm.tsx
@@ -9,7 +9,8 @@ import {
   FormikTextInput,
   FormikTextarea,
   MultiRadio,
-  THEME
+  THEME,
+  useNewWindow
 } from '@mtes-mct/monitor-ui'
 import { FieldArray, useFormikContext } from 'formik'
 import { useMemo } from 'react'
@@ -40,6 +41,8 @@ export function GeneralInformationsForm({
 }: {
   missionCompletion?: FrontCompletionStatus
 }) {
+  const { newWindowContainerRef } = useNewWindow()
+
   const currentPath = useAppSelector(state => state.sideWindow.currentPath)
 
   const { errors, setFieldValue, values } = useFormikContext<Mission>()
@@ -90,6 +93,7 @@ export function GeneralInformationsForm({
           <div>
             <StyledDatePickerContainer>
               <DatePicker
+                baseContainer={newWindowContainerRef.current}
                 data-cy="mission-start-date-time"
                 defaultValue={values?.startDateTimeUtc || undefined}
                 isCompact
@@ -103,6 +107,7 @@ export function GeneralInformationsForm({
               />
 
               <StyledFormikDatePicker
+                baseContainer={newWindowContainerRef.current}
                 data-cy="mission-end-date-time"
                 isCompact
                 isEndDate

--- a/frontend/src/features/missions/MissionsList/Filters/index.tsx
+++ b/frontend/src/features/missions/MissionsList/Filters/index.tsx
@@ -9,7 +9,8 @@ import {
   getOptionsFromLabelledEnum,
   CustomSearch,
   Icon,
-  Checkbox
+  Checkbox,
+  useNewWindow
 } from '@mtes-mct/monitor-ui'
 import { type MutableRefObject, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -28,6 +29,8 @@ import { useGetControlPlans } from '../../../../hooks/useGetControlPlans'
 import { isNotArchived } from '../../../../utils/isNotArchived'
 
 export function MissionsTableFilters() {
+  const { newWindowContainerRef } = useNewWindow()
+
   const dispatch = useAppDispatch()
   const {
     hasFilters,
@@ -283,6 +286,7 @@ export function MissionsTableFilters() {
           <StyledCustomPeriodContainer>
             <DateRangePicker
               key="dateRange"
+              baseContainer={newWindowContainerRef.current}
               data-cy="datepicker-missionStartedAfter"
               defaultValue={
                 startedAfter && startedBefore ? [new Date(startedAfter), new Date(startedBefore)] : undefined


### PR DESCRIPTION
- Fix des datePicker sans `baseContainer`
- Taille fixe de 400px pour les colonnes `nom` des tableaux du back office

## Related Pull Requests & Issues

- Resolve #1460


<img width="1512" alt="Capture d’écran 2024-06-14 à 13 31 26" src="https://github.com/MTES-MCT/monitorenv/assets/23258718/c291b49b-10b5-4d84-a5b6-b3ad2958a5a6">
