### PR TITLE
[Mission] Résolution du bug sur le filtre de date "aujourd'hui" dans la liste des missions

### DIFF
--- a/frontend/src/features/Reportings/hooks/useGetFilteredReportingsQuery.ts
+++ b/frontend/src/features/Reportings/hooks/useGetFilteredReportingsQuery.ts
@@ -55,21 +55,21 @@ export const useGetFilteredReportingsQuery = () => {
     const startedBeforeDate = startedBefore ?? undefined
     switch (periodFilter) {
       case ReportingDateRangeEnum.DAY:
-        startedAfterDate = customDayjs.utc().subtract(24, 'hour').toISOString()
+        startedAfterDate = customDayjs().utc().subtract(24, 'hour').toISOString()
 
         break
 
       case ReportingDateRangeEnum.WEEK:
-        startedAfterDate = customDayjs.utc().startOf('day').utc().subtract(7, 'day').toISOString()
+        startedAfterDate = customDayjs().utc().startOf('day').utc().subtract(7, 'day').toISOString()
 
         break
 
       case ReportingDateRangeEnum.MONTH:
-        startedAfterDate = customDayjs.utc().startOf('day').utc().subtract(30, 'day').toISOString()
+        startedAfterDate = customDayjs().utc().startOf('day').utc().subtract(30, 'day').toISOString()
 
         break
       case ReportingDateRangeEnum.YEAR:
-        startedAfterDate = customDayjs.utc().startOf('year').toISOString()
+        startedAfterDate = customDayjs().utc().startOf('year').toISOString()
 
         break
 

--- a/frontend/src/hooks/useGetFilteredMissionsQuery.ts
+++ b/frontend/src/hooks/useGetFilteredMissionsQuery.ts
@@ -33,7 +33,7 @@ export const useGetFilteredMissionsQuery = () => {
 
     switch (selectedPeriod) {
       case DateRangeEnum.DAY:
-        startedAfterDate = customDayjs.utc().subtract(24, 'hour').toISOString()
+        startedAfterDate = customDayjs().utc().startOf('day').toISOString()
 
         break
 

--- a/frontend/src/hooks/useGetFilteredMissionsQuery.ts
+++ b/frontend/src/hooks/useGetFilteredMissionsQuery.ts
@@ -38,12 +38,12 @@ export const useGetFilteredMissionsQuery = () => {
         break
 
       case DateRangeEnum.WEEK:
-        startedAfterDate = customDayjs.utc().startOf('day').utc().subtract(7, 'day').toISOString()
+        startedAfterDate = customDayjs().utc().startOf('day').utc().subtract(7, 'day').toISOString()
 
         break
 
       case DateRangeEnum.MONTH:
-        startedAfterDate = customDayjs.utc().startOf('day').utc().subtract(30, 'day').toISOString()
+        startedAfterDate = customDayjs().utc().startOf('day').utc().subtract(30, 'day').toISOString()
 
         break
 


### PR DESCRIPTION
Suite à une mise à jour de la façon de gérer le filtre de date j'avais copié/collé le filtre des reportings qui va chercher les dernières 24H au lieu du jour en cours pour les missions

## Related Pull Requests & Issues

- Resolve #1466


----

- [ ] Tests E2E (Cypress)
