### PR TITLE
[Mission] Résolution du bug de suppression de contrôle

### DIFF
--- a/frontend/src/features/missions/MissionForm/hooks/useUpdateMissionZone.ts
+++ b/frontend/src/features/missions/MissionForm/hooks/useUpdateMissionZone.ts
@@ -37,7 +37,16 @@ export const useUpdateMissionZone = (sortedActions: Array<ActionsTypeForTimeLine
   )
 
   const firstAction = filteredEnvActions[0]
-  const firstActionWithDate = firstAction?.actionStartDateTimeUtc ? firstAction : undefined
+  const firstActionWithDate = useMemo(() => {
+    if (firstAction?.actionType === ActionTypeEnum.SURVEILLANCE) {
+      return firstAction?.actionStartDateTimeUtc ? firstAction : undefined
+    }
+    if (firstAction?.actionType === ActionTypeEnum.CONTROL) {
+      return firstAction?.actionEndDateTimeUtc ? firstAction : undefined
+    }
+
+    return undefined
+  }, [firstAction])
 
   const listener = useAppSelector(state => state.draw.listener)
   const { setFieldValue, values } = useFormikContext<Mission>()


### PR DESCRIPTION
Quand on supprime un contrôle et que l'action suivante (dans le temps) est aussi un contrôle, le formulaire plante que j'allais chercher `actionStartDateTimeUtc` qui n'existe pas sur les contrôles. Il faut prendre `actionEndDateTimeUtc`

## Related Pull Requests & Issues

- Resolve #1468

----

- [ ] Tests E2E (Cypress)
