### PR TITLE
[Tech] set Mission's start/endDateTime as patchable

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/MissionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/MissionEntity.kt
@@ -19,9 +19,9 @@ data class MissionEntity(
     val facade: String? = null,
     val geom: MultiPolygon? = null,
     @Patchable
-    val startDateTimeUtc: ZonedDateTime,
+    var startDateTimeUtc: ZonedDateTime,
     @Patchable
-    val endDateTimeUtc: ZonedDateTime? = null,
+    var endDateTimeUtc: ZonedDateTime? = null,
     val createdAtUtc: ZonedDateTime? = null,
     val updatedAtUtc: ZonedDateTime? = null,
     val envActions: List<EnvActionEntity>? = listOf(),

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/MissionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/MissionEntity.kt
@@ -18,7 +18,9 @@ data class MissionEntity(
     val observationsCnsp: String? = null,
     val facade: String? = null,
     val geom: MultiPolygon? = null,
+    @Patchable
     val startDateTimeUtc: ZonedDateTime,
+    @Patchable
     val endDateTimeUtc: ZonedDateTime? = null,
     val createdAtUtc: ZonedDateTime? = null,
     val updatedAtUtc: ZonedDateTime? = null,

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/PatchableMissionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/PatchableMissionEntity.kt
@@ -1,5 +1,10 @@
 package fr.gouv.cacem.monitorenv.domain.entities.mission
 
+import java.time.ZonedDateTime
 import java.util.Optional
 
-data class PatchableMissionEntity(val observationsByUnit: Optional<String>?)
+data class PatchableMissionEntity(
+    val observationsByUnit: Optional<String>?,
+    val startDateTimeUtc: Optional<ZonedDateTime>?,
+    val endDateTimeUtc: Optional<ZonedDateTime>?,
+)

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/PatchableMissionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/PatchableMissionEntity.kt
@@ -5,6 +5,6 @@ import java.util.Optional
 
 data class PatchableMissionEntity(
     val observationsByUnit: Optional<String>?,
-    val startDateTimeUtc: Optional<ZonedDateTime>?,
+    val startDateTimeUtc: ZonedDateTime?,
     val endDateTimeUtc: Optional<ZonedDateTime>?,
 )

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchEntity.kt
@@ -10,7 +10,18 @@ import kotlin.reflect.full.memberProperties
 @UseCase
 class PatchEntity<T : Any, S : Any> {
 
-    fun execute(target: T, source: S): T {
+    /**
+     * Patches the target entity with values from the source entity.
+     *
+     * This function updates the target entity with values from the source entity for properties
+     * annotated with @Patchable. If a property in the source entity is null, the existing value
+     * in the target entity is retained. If a property in the source entity is an Optional, it
+     * is handled accordingly.
+     *
+     * @param target The target entity to be patched.
+     * @param source The source entity providing the patch values.
+     */
+    fun execute(target: T, source: S) {
         val sourceProperties = source::class.memberProperties
         val targetProperties = target::class.memberProperties
 
@@ -29,8 +40,6 @@ class PatchEntity<T : Any, S : Any> {
                 targetProp.setter.call(target, finalValue)
             }
         }
-
-        return target
     }
 
     private fun getValueFromOptional(existingValue: Any?, optional: Optional<*>?): Any? {

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/actions/PatchEnvAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/actions/PatchEnvAction.kt
@@ -17,7 +17,8 @@ class PatchEnvAction(
 
     fun execute(id: UUID, patchableEnvActionEntity: PatchableEnvActionEntity): EnvActionEntity {
         envActionRepository.findById(id)?.let {
-            return envActionRepository.save(patchEnvAction.execute(it, patchableEnvActionEntity))
+            patchEnvAction.execute(it, patchableEnvActionEntity)
+            return envActionRepository.save(it)
         }
         throw BackendUsageException(BackendUsageErrorCode.ENTITY_NOT_FOUND, "envAction $id not found")
     }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMission.kt
@@ -17,7 +17,8 @@ class PatchMission(
 
     fun execute(id: Int, patchableMissionEntity: PatchableMissionEntity): MissionDTO {
         missionRepository.findById(id)?.let {
-            return missionRepository.save(patchEntity.execute(it, patchableMissionEntity))
+            patchEntity.execute(it, patchableMissionEntity)
+            return missionRepository.save(it)
         }
         throw BackendUsageException(BackendUsageErrorCode.ENTITY_NOT_FOUND, "mission $id not found")
     }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/PatchableMissionDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/PatchableMissionDataInput.kt
@@ -1,14 +1,19 @@
 package fr.gouv.cacem.monitorenv.infrastructure.api.adapters.publicapi.inputs
 
 import fr.gouv.cacem.monitorenv.domain.entities.mission.PatchableMissionEntity
+import java.time.ZonedDateTime
 import java.util.Optional
 
 data class PatchableMissionDataInput(
     val observationsByUnit: Optional<String>?,
+    val startDateTimeUtc: Optional<ZonedDateTime>?,
+    val endDateTimeUtc: Optional<ZonedDateTime>?,
 ) {
     fun toPatchableMissionEntity(): PatchableMissionEntity {
         return PatchableMissionEntity(
             observationsByUnit = observationsByUnit,
+            startDateTimeUtc = startDateTimeUtc,
+            endDateTimeUtc = endDateTimeUtc,
         )
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/PatchableMissionDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/PatchableMissionDataInput.kt
@@ -6,7 +6,7 @@ import java.util.Optional
 
 data class PatchableMissionDataInput(
     val observationsByUnit: Optional<String>?,
-    val startDateTimeUtc: Optional<ZonedDateTime>?,
+    val startDateTimeUtc: ZonedDateTime?,
     val endDateTimeUtc: Optional<ZonedDateTime>?,
 ) {
     fun toPatchableMissionEntity(): PatchableMissionEntity {

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchEnvActionEntityUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchEnvActionEntityUTest.kt
@@ -33,10 +33,10 @@ class PatchEnvActionEntityUTest {
         )
 
         // When
-        val mergedEnvAction = patchEntity.execute(envAction, patchableEnvActionEntity)
+        patchEntity.execute(envAction, patchableEnvActionEntity)
 
         // Then
-        assertThat(mergedEnvAction.actionStartDateTimeUtc).isEqualTo(today)
+        assertThat(envAction.actionStartDateTimeUtc).isEqualTo(today)
     }
 
     @Test
@@ -55,10 +55,10 @@ class PatchEnvActionEntityUTest {
         )
 
         // When
-        val mergedEnvAction = patchEntity.execute(envAction, patchableEnvActionEntity)
+        patchEntity.execute(envAction, patchableEnvActionEntity)
 
         // Then
-        assertThat(mergedEnvAction.actionStartDateTimeUtc).isNull()
+        assertThat(envAction.actionStartDateTimeUtc).isNull()
     }
 
     @Test
@@ -79,10 +79,10 @@ class PatchEnvActionEntityUTest {
         )
 
         // When
-        val mergedEnvAction = patchEntity.execute(envAction, patchableEnvActionEntity)
+        patchEntity.execute(envAction, patchableEnvActionEntity)
 
         // Then
-        assertThat(mergedEnvAction.actionEndDateTimeUtc).isEqualTo(today)
+        assertThat(envAction.actionEndDateTimeUtc).isEqualTo(today)
     }
 
     @Test
@@ -101,10 +101,10 @@ class PatchEnvActionEntityUTest {
         )
 
         // When
-        val mergedEnvAction = patchEntity.execute(envAction, patchableEnvActionEntity)
+        patchEntity.execute(envAction, patchableEnvActionEntity)
 
         // Then
-        assertThat(mergedEnvAction.actionEndDateTimeUtc).isNull()
+        assertThat(envAction.actionEndDateTimeUtc).isNull()
     }
 
     @Test
@@ -125,10 +125,10 @@ class PatchEnvActionEntityUTest {
         )
 
         // When
-        val mergedEnvAction = patchEntity.execute(envAction, patchableEnvActionEntity)
+        patchEntity.execute(envAction, patchableEnvActionEntity)
 
         // Then
-        assertThat(mergedEnvAction.observationsByUnit).isEqualTo(observationsByUnit)
+        assertThat(envAction.observationsByUnit).isEqualTo(observationsByUnit)
     }
 
     @Test
@@ -147,10 +147,10 @@ class PatchEnvActionEntityUTest {
         )
 
         // When
-        val mergedEnvAction = patchEntity.execute(envAction, patchableEnvActionEntity)
+        patchEntity.execute(envAction, patchableEnvActionEntity)
 
         // Then
-        assertThat(mergedEnvAction.observationsByUnit).isNull()
+        assertThat(envAction.observationsByUnit).isNull()
     }
 
     @Test
@@ -170,11 +170,11 @@ class PatchEnvActionEntityUTest {
         )
 
         // When
-        val mergedEnvAction = patchEntity.execute(envAction, patchableEnvActionEntity)
+        patchEntity.execute(envAction, patchableEnvActionEntity)
 
         // Then
-        assertThat(mergedEnvAction.observationsByUnit).isEqualTo(observationsByUnit)
-        assertThat(mergedEnvAction.actionStartDateTimeUtc).isEqualTo(yesterday)
-        assertThat(mergedEnvAction.actionEndDateTimeUtc).isEqualTo(tomorrow)
+        assertThat(envAction.observationsByUnit).isEqualTo(observationsByUnit)
+        assertThat(envAction.actionStartDateTimeUtc).isEqualTo(yesterday)
+        assertThat(envAction.actionEndDateTimeUtc).isEqualTo(tomorrow)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchMissionEntityUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchMissionEntityUTest.kt
@@ -24,10 +24,10 @@ class PatchMissionEntityUTest {
         )
 
         // When
-        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+        patchEntity.execute(missionEntity, patchableMissionEntity)
 
         // Then
-        assertThat(mergedMissionEntity.observationsByUnit).isEqualTo(observationsByUnit)
+        assertThat(missionEntity.observationsByUnit).isEqualTo(observationsByUnit)
     }
 
     @Test
@@ -41,10 +41,10 @@ class PatchMissionEntityUTest {
         )
 
         // When
-        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+        patchEntity.execute(missionEntity, patchableMissionEntity)
 
         // Then
-        assertThat(mergedMissionEntity.observationsByUnit).isNull()
+        assertThat(missionEntity.observationsByUnit).isNull()
     }
 
     @Test
@@ -59,10 +59,10 @@ class PatchMissionEntityUTest {
         )
 
         // When
-        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+        patchEntity.execute(missionEntity, patchableMissionEntity)
 
         // Then
-        assertThat(mergedMissionEntity.observationsByUnit).isEqualTo(observationsByUnit)
+        assertThat(missionEntity.observationsByUnit).isEqualTo(observationsByUnit)
     }
 
 
@@ -79,17 +79,22 @@ class PatchMissionEntityUTest {
         )
 
         // When
-        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+        patchEntity.execute(missionEntity, patchableMissionEntity)
 
         // Then
-        assertThat(mergedMissionEntity.startDateTimeUtc).isEqualTo(startDateTimeUtc)
-        assertThat(mergedMissionEntity.endDateTimeUtc).isEqualTo(endDateTimeUtc)
+        assertThat(missionEntity.startDateTimeUtc).isEqualTo(startDateTimeUtc)
+        assertThat(missionEntity.endDateTimeUtc).isEqualTo(endDateTimeUtc)
     }
 
     @Test
     fun `execute() should return the original datetime if given as null`() {
         // Given
-        val missionEntity = MissionFixture.aMissionEntity()
+        val startDateTimeUtc = ZonedDateTime.parse("2024-04-11T07:00:00Z")
+        val endDateTimeUtc = ZonedDateTime.parse("2024-04-22T07:00:00Z")
+        val missionEntity = MissionFixture.aMissionEntity(
+            startDateTimeUtc = startDateTimeUtc,
+            endDateTimeUtc =  endDateTimeUtc
+        )
         val patchableMissionEntity = PatchableMissionEntity(
             observationsByUnit = Optional.empty(),
             startDateTimeUtc = null,
@@ -97,11 +102,11 @@ class PatchMissionEntityUTest {
         )
 
         // When
-        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+        patchEntity.execute(missionEntity, patchableMissionEntity)
 
         // Then
-        assertThat(mergedMissionEntity.startDateTimeUtc).isEqualTo(missionEntity.startDateTimeUtc)
-        assertThat(mergedMissionEntity.endDateTimeUtc).isEqualTo(missionEntity.endDateTimeUtc)
+        assertThat(missionEntity.startDateTimeUtc).isEqualTo(startDateTimeUtc)
+        assertThat(missionEntity.endDateTimeUtc).isEqualTo(endDateTimeUtc)
     }
 
     @Test
@@ -115,9 +120,9 @@ class PatchMissionEntityUTest {
         )
 
         // When
-        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+        patchEntity.execute(missionEntity, patchableMissionEntity)
 
         // Then
-        assertThat(mergedMissionEntity.endDateTimeUtc).isNull()
+        assertThat(missionEntity.endDateTimeUtc).isNull()
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchMissionEntityUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchMissionEntityUTest.kt
@@ -5,6 +5,7 @@ import fr.gouv.cacem.monitorenv.domain.entities.mission.PatchableMissionEntity
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.fixtures.MissionFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 import java.util.*
 
 class PatchMissionEntityUTest {
@@ -16,7 +17,11 @@ class PatchMissionEntityUTest {
         // Given
         val observationsByUnit = "observationsByUnit"
         val missionEntity = MissionFixture.aMissionEntity()
-        val patchableMissionEntity = PatchableMissionEntity(observationsByUnit = Optional.of(observationsByUnit))
+        val patchableMissionEntity = PatchableMissionEntity(
+            observationsByUnit = Optional.of(observationsByUnit),
+            startDateTimeUtc = null,
+            endDateTimeUtc = null
+        )
 
         // When
         val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
@@ -29,7 +34,11 @@ class PatchMissionEntityUTest {
     fun `execute() should return mission with observationsByUnit null if its empty`() {
         // Given
         val missionEntity = MissionFixture.aMissionEntity()
-        val patchableMissionEntity = PatchableMissionEntity(observationsByUnit = Optional.empty())
+        val patchableMissionEntity = PatchableMissionEntity(
+            observationsByUnit = Optional.empty(),
+            startDateTimeUtc = null,
+            endDateTimeUtc = null
+        )
 
         // When
         val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
@@ -43,12 +52,54 @@ class PatchMissionEntityUTest {
         // Given
         val observationsByUnit = "old value"
         val missionEntity = MissionFixture.aMissionEntity(observationsByUnit = observationsByUnit)
-        val patchableMissionEntity = PatchableMissionEntity(observationsByUnit = null)
+        val patchableMissionEntity = PatchableMissionEntity(
+            observationsByUnit = null,
+            startDateTimeUtc = null,
+            endDateTimeUtc = Optional.empty(),
+        )
 
         // When
         val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
 
         // Then
         assertThat(mergedMissionEntity.observationsByUnit).isEqualTo(observationsByUnit)
+    }
+
+
+    @Test
+    fun `execute() should return mission with start+endDateTimes modified if its present`() {
+        // Given
+        val startDateTimeUtc = ZonedDateTime.parse("2024-04-11T07:00:00Z")
+        val endDateTimeUtc = ZonedDateTime.parse("2024-04-22T07:00:00Z")
+        val missionEntity = MissionFixture.aMissionEntity()
+        val patchableMissionEntity = PatchableMissionEntity(
+            observationsByUnit = Optional.empty(),
+            startDateTimeUtc = Optional.of(startDateTimeUtc),
+            endDateTimeUtc = Optional.of(endDateTimeUtc)
+        )
+
+        // When
+        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+
+        // Then
+        assertThat(mergedMissionEntity.startDateTimeUtc).isEqualTo(startDateTimeUtc)
+        assertThat(mergedMissionEntity.endDateTimeUtc).isEqualTo(endDateTimeUtc)
+    }
+
+    @Test
+    fun `execute() should return mission with endDateTimes null if its empty`() {
+        // Given
+        val missionEntity = MissionFixture.aMissionEntity()
+        val patchableMissionEntity = PatchableMissionEntity(
+            observationsByUnit = Optional.empty(),
+            startDateTimeUtc = null,
+            endDateTimeUtc = Optional.empty()
+        )
+
+        // When
+        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+
+        // Then
+        assertThat(mergedMissionEntity.endDateTimeUtc).isNull()
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchMissionEntityUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/mappers/PatchMissionEntityUTest.kt
@@ -74,7 +74,7 @@ class PatchMissionEntityUTest {
         val missionEntity = MissionFixture.aMissionEntity()
         val patchableMissionEntity = PatchableMissionEntity(
             observationsByUnit = Optional.empty(),
-            startDateTimeUtc = Optional.of(startDateTimeUtc),
+            startDateTimeUtc = startDateTimeUtc,
             endDateTimeUtc = Optional.of(endDateTimeUtc)
         )
 
@@ -84,6 +84,24 @@ class PatchMissionEntityUTest {
         // Then
         assertThat(mergedMissionEntity.startDateTimeUtc).isEqualTo(startDateTimeUtc)
         assertThat(mergedMissionEntity.endDateTimeUtc).isEqualTo(endDateTimeUtc)
+    }
+
+    @Test
+    fun `execute() should return the original datetime if given as null`() {
+        // Given
+        val missionEntity = MissionFixture.aMissionEntity()
+        val patchableMissionEntity = PatchableMissionEntity(
+            observationsByUnit = Optional.empty(),
+            startDateTimeUtc = null,
+            endDateTimeUtc = null
+        )
+
+        // When
+        val mergedMissionEntity = patchEntity.execute(missionEntity, patchableMissionEntity)
+
+        // Then
+        assertThat(mergedMissionEntity.startDateTimeUtc).isEqualTo(missionEntity.startDateTimeUtc)
+        assertThat(mergedMissionEntity.endDateTimeUtc).isEqualTo(missionEntity.endDateTimeUtc)
     }
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/actions/PatchEnvActionUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/actions/PatchEnvActionUTest.kt
@@ -19,7 +19,7 @@ import java.util.*
 class PatchEnvActionUTest {
 
     private val envActionRepository: IEnvActionRepository = mock()
-    private val patchEntity: PatchEntity<EnvActionEntity, PatchableEnvActionEntity> = mock()
+    private val patchEntity: PatchEntity<EnvActionEntity, PatchableEnvActionEntity> = PatchEntity()
     private val patchEnvAction: PatchEnvAction = PatchEnvAction(envActionRepository, patchEntity)
     private val objectMapper: ObjectMapper = ObjectMapper()
 
@@ -31,7 +31,11 @@ class PatchEnvActionUTest {
         val tomorrow = ZonedDateTime.now().plusDays(1)
         val observationsByUnit = "observations"
         val patchedObservationsByUnit = "patched observations"
-        val patchableEnvActionEntity = PatchableEnvActionEntity(null, null, null)
+        val patchableEnvActionEntity = PatchableEnvActionEntity(
+            Optional.of(today),
+            Optional.of(tomorrow),
+            Optional.of(patchedObservationsByUnit)
+        )
         val envActionFromDatabase = anEnvAction(
             objectMapper,
             id,
@@ -43,9 +47,7 @@ class PatchEnvActionUTest {
             anEnvAction(objectMapper, envActionFromDatabase.id, today, tomorrow, patchedObservationsByUnit)
 
         given(envActionRepository.findById(id)).willReturn(envActionFromDatabase)
-        given(patchEntity.execute(envActionFromDatabase, patchableEnvActionEntity)).willReturn(
-            envActionPatched,
-        )
+        patchEntity.execute(envActionFromDatabase, patchableEnvActionEntity)
         given(envActionRepository.save(envActionPatched)).willReturn(envActionPatched)
 
         // When

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMissionUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMissionUTest.kt
@@ -13,33 +13,38 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
+import java.time.ZonedDateTime
 import java.util.*
 import kotlin.random.Random
 
 class PatchMissionUTest {
 
     private val missionRepository: IMissionRepository = mock()
-    private val patchEntity: PatchEntity<MissionEntity, PatchableMissionEntity> = mock()
+    private val patchEntity: PatchEntity<MissionEntity, PatchableMissionEntity> = PatchEntity()
     private val patchMission: PatchMission = PatchMission(missionRepository, patchEntity)
 
     @Test
     fun `execute() should return the patched entity`() {
         // Given
         val id = Random.nextInt()
-        val observationsByUnit = Optional.of("observations")
+        val today = ZonedDateTime.now()
+        val tomorrow = ZonedDateTime.now().plusDays(1)
         val patchedObservationsByUnit = "patched observations"
         val patchableMission = PatchableMissionEntity(
-            observationsByUnit = observationsByUnit,
-            startDateTimeUtc = null,
-            endDateTimeUtc = null
+            observationsByUnit = Optional.of(patchedObservationsByUnit),
+            startDateTimeUtc = today,
+            endDateTimeUtc = Optional.of(tomorrow)
         )
-        val missionFromDatabase = aMissionEntity()
-        val missionPatched = aMissionEntity(observationsByUnit = patchedObservationsByUnit)
+        val missionFromDatabase = aMissionEntity(id = id)
+        val missionPatched = aMissionEntity(
+            id = id,
+            observationsByUnit = patchedObservationsByUnit,
+            startDateTimeUtc = today,
+            endDateTimeUtc = tomorrow
+        )
 
         given(missionRepository.findById(id)).willReturn(missionFromDatabase)
-        given(patchEntity.execute(missionFromDatabase, patchableMission)).willReturn(
-            missionPatched,
-        )
+        patchEntity.execute(missionFromDatabase, patchableMission)
         given(missionRepository.save(missionPatched)).willReturn(MissionDTO(missionPatched))
 
         // When
@@ -47,6 +52,8 @@ class PatchMissionUTest {
 
         // Then
         assertThat(savedMission.mission.observationsByUnit).isEqualTo(missionPatched.observationsByUnit)
+        assertThat(savedMission.mission.startDateTimeUtc).isEqualTo(missionPatched.startDateTimeUtc)
+        assertThat(savedMission.mission.endDateTimeUtc).isEqualTo(missionPatched.endDateTimeUtc)
         verify(missionRepository).save(missionPatched)
     }
 

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMissionUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMissionUTest.kt
@@ -28,7 +28,11 @@ class PatchMissionUTest {
         val id = Random.nextInt()
         val observationsByUnit = Optional.of("observations")
         val patchedObservationsByUnit = "patched observations"
-        val patchableMission = PatchableMissionEntity(observationsByUnit = observationsByUnit)
+        val patchableMission = PatchableMissionEntity(
+            observationsByUnit = observationsByUnit,
+            startDateTimeUtc = null,
+            endDateTimeUtc = null
+        )
         val missionFromDatabase = aMissionEntity()
         val missionPatched = aMissionEntity(observationsByUnit = patchedObservationsByUnit)
 
@@ -50,7 +54,11 @@ class PatchMissionUTest {
     fun `execute() should throw BackendUsageException with message when the entity does not exist`() {
         // Given
         val id = Random.nextInt()
-        val patchableMission = PatchableMissionEntity(observationsByUnit = null)
+        val patchableMission = PatchableMissionEntity(
+            observationsByUnit = null,
+            startDateTimeUtc = null,
+            endDateTimeUtc = null
+        )
 
         given(missionRepository.findById(id)).willReturn(null)
 

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/fixtures/MissionFixture.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/fixtures/MissionFixture.kt
@@ -9,15 +9,20 @@ import kotlin.random.Random
 class MissionFixture {
 
     companion object {
-        fun aMissionEntity(observationsByUnit: String? = null): MissionEntity {
+        fun aMissionEntity(
+            id: Int? = Random.nextInt(),
+            startDateTimeUtc: ZonedDateTime = ZonedDateTime.parse("2022-01-15T04:50:09Z"),
+            endDateTimeUtc: ZonedDateTime? = ZonedDateTime.parse("2022-01-23T20:29:03Z"),
+            observationsByUnit: String? = null
+        ): MissionEntity {
             return MissionEntity(
-                id = Random.nextInt(),
+                id = id,
                 observationsByUnit = observationsByUnit,
                 missionTypes = listOf(MissionTypeEnum.LAND),
                 facade = "Outre-Mer",
                 geom = null,
-                startDateTimeUtc = ZonedDateTime.parse("2022-01-15T04:50:09Z"),
-                endDateTimeUtc = ZonedDateTime.parse("2022-01-23T20:29:03Z"),
+                startDateTimeUtc = startDateTimeUtc,
+                endDateTimeUtc = endDateTimeUtc,
                 isDeleted = false,
                 missionSource = MissionSourceEnum.MONITORENV,
                 hasMissionOrder = false,

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/v2/MissionsITest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/v2/MissionsITest.kt
@@ -75,7 +75,7 @@ class MissionsITest {
         )
         val patchableMissionEntity = PatchableMissionEntity(
             observationsByUnit = Optional.of(observationsByUnit),
-            startDateTimeUtc = Optional.of(startDateTimeUtc),
+            startDateTimeUtc = startDateTimeUtc,
             endDateTimeUtc = Optional.of(endDateTimeUtc),
         )
 

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/v2/MissionsITest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/publicapi/v2/MissionsITest.kt
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.ZonedDateTime
 import java.util.*
 import kotlin.random.Random
 
@@ -55,23 +56,36 @@ class MissionsITest {
     fun `patch() should call the usecase to patch the data then return the updated resources`() {
         // Given
         val id = Random.nextInt()
-        val observationsByUnit = "observationsByUnits"
+
+        // patched fields
+        val observationsByUnit = "patchedObservations"
+        val startDateTimeUtc: ZonedDateTime = ZonedDateTime.parse("2024-04-11T07:00:00Z")
+        val endDateTimeUtc: ZonedDateTime = ZonedDateTime.parse("2024-04-22T07:00:00Z")
+
         val partialMissionAsJson =
             """
-            { "observationsByUnit": "$observationsByUnit"}
+            { "observationsByUnit": "$observationsByUnit", "startDateTimeUtc": "$startDateTimeUtc", "endDateTimeUtc": "$endDateTimeUtc" }
             """.trimIndent()
-        val patchedMission = aMissionEntity(observationsByUnit = "patchedObservations")
-        val patchableMissionEntity =
-            PatchableMissionEntity(
-                Optional.of(observationsByUnit),
-            )
+
+        val patchedMission = aMissionEntity(
+            id = id,
+            observationsByUnit = observationsByUnit,
+            startDateTimeUtc = startDateTimeUtc,
+            endDateTimeUtc = endDateTimeUtc
+        )
+        val patchableMissionEntity = PatchableMissionEntity(
+            observationsByUnit = Optional.of(observationsByUnit),
+            startDateTimeUtc = Optional.of(startDateTimeUtc),
+            endDateTimeUtc = Optional.of(endDateTimeUtc),
+        )
 
         given(patchMission.execute(id, patchableMissionEntity))
-            .willReturn(MissionDTO(patchedMission))
+            .willReturn(MissionDTO(mission = patchedMission))
 
         // When
         mockMvc.perform(
             patch("/api/v2/missions/$id")
+                .characterEncoding("utf-8")
                 .content(partialMissionAsJson)
                 .contentType(MediaType.APPLICATION_JSON),
         )


### PR DESCRIPTION
## Description

Similairement au champ 'observationsByUnit', j'aimerais rendre les champs start/endDateTime patchable. 
Il est beaucoup plus facile pour nous d'utiliser l'endpoint v2 pour patcher plutot que l'endpoint v1 qui requiert toute la mission

----

- [ ] Tests E2E (Cypress)
