### PR TITLE
[Zone de vigilance] Résolution du bug de doublon de nom de la zone dans la liste des résultats

### DIFF
--- a/frontend/src/features/layersSelector/search/ResultsList/VigilanceAreaLayer/index.tsx
+++ b/frontend/src/features/layersSelector/search/ResultsList/VigilanceAreaLayer/index.tsx
@@ -90,7 +90,6 @@ export function VigilanceAreaLayer({ layerId, searchedText }: RegulatoryLayerPro
           searchWords={searchedText && searchedText.length > 0 ? searchedText.split(' ') : []}
           textToHighlight={layer?.name ?? ''}
         />
-        {layer?.name ?? 'AUCUN NOM'}
       </LayerSelector.Name>
       <LayerSelector.IconGroup>
         <IconButton


### PR DESCRIPTION
Suppression du doublon du nom de la zone de vigilance dans la liste des résultats de recherche
## Related Pull Requests & Issues

- Resolve #1578 

----

- [ ] Tests E2E (Cypress)
