### PR TITLE
[Tech] Rendre actionEndDateTimeUtc patchable pour Controles + Surveil

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/outputs/MissionEnvActionControlDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/outputs/MissionEnvActionControlDataOutput.kt
@@ -12,7 +12,7 @@ import java.util.*
 
 data class MissionEnvActionControlDataOutput(
     override val id: UUID,
-    val actionEndDateTimeUtc: ZonedDateTime? = null,
+    override val actionEndDateTimeUtc: ZonedDateTime? = null,
     val actionNumberOfControls: Int? = null,
     override val actionStartDateTimeUtc: ZonedDateTime? = null,
     val actionTargetType: ActionTargetTypeEnum? = null,
@@ -36,6 +36,7 @@ data class MissionEnvActionControlDataOutput(
     MissionEnvActionDataOutput(
         id = id,
         actionStartDateTimeUtc = actionStartDateTimeUtc,
+        actionEndDateTimeUtc = actionEndDateTimeUtc,
         actionType = ActionTypeEnum.CONTROL,
     ) {
     companion object {

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/outputs/MissionEnvActionDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/outputs/MissionEnvActionDataOutput.kt
@@ -11,6 +11,7 @@ import java.util.*
 abstract class MissionEnvActionDataOutput(
     open val id: UUID,
     open val actionStartDateTimeUtc: ZonedDateTime? = null,
+    open val actionEndDateTimeUtc: ZonedDateTime? = null,
     open val actionType: ActionTypeEnum,
     open val observationsByUnit: String? = null,
 ) {

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/outputs/MissionEnvActionSurveillanceDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/outputs/MissionEnvActionSurveillanceDataOutput.kt
@@ -9,7 +9,7 @@ import java.util.*
 
 data class MissionEnvActionSurveillanceDataOutput(
     override val id: UUID,
-    val actionEndDateTimeUtc: ZonedDateTime? = null,
+    override val actionEndDateTimeUtc: ZonedDateTime? = null,
     override val actionStartDateTimeUtc: ZonedDateTime? = null,
     override val actionType: ActionTypeEnum = ActionTypeEnum.SURVEILLANCE,
     val completedBy: String? = null,
@@ -25,6 +25,7 @@ data class MissionEnvActionSurveillanceDataOutput(
     MissionEnvActionDataOutput(
         id = id,
         actionStartDateTimeUtc = actionStartDateTimeUtc,
+        actionEndDateTimeUtc = actionEndDateTimeUtc,
         actionType = ActionTypeEnum.SURVEILLANCE,
         observationsByUnit = observationsByUnit,
     ) {


### PR DESCRIPTION
## Description

Le champ actionEndDateTimeUtc ne semblait pas être retourné après un patch donc j'ai fait les modifs. 

Ceci, je me demande si je n'ai pas oublié qqch...

----

- [ ] Tests E2E (Cypress)
