### PR TITLE
[Tech] Ne plus afficher les zones de mission quand on ouvre une autre pop-up

### DIFF
--- a/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
+++ b/frontend/src/features/map/overlays/OverlayPositionOnCentroid.tsx
@@ -185,13 +185,9 @@ export function OverlayPositionOnCentroid({
       const featureId = String(nextFeature.getId())
       if (!featureId.includes(Layers.SEMAPHORES.code)) {
         dispatch(resetSelectedSemaphore())
-
-        return
       }
       if (!featureId.includes(Layers.MISSIONS.code)) {
         dispatch(missionActions.resetSelectedMissionIdOnMap())
-
-        return
       }
 
       if (!featureId.includes(Layers.REPORTINGS.code)) {


### PR DESCRIPTION
## Related Pull Requests & Issues

-  #1003

----

- [ ] Tests E2E (Cypress)
