### PR TITLE
[Zone de vigilance] Amélioration UI/UX de la fonctionnalité d'ajout d'images

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/bff/outputs/ExtractedAreaDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/bff/outputs/ExtractedAreaDataOutput.kt
@@ -4,14 +4,14 @@ import fr.gouv.cacem.monitorenv.domain.entities.dashboard.ExtractedAreaEntity
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.outputs.AMPDataOutput.Companion.fromAMPEntity
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.outputs.RegulatoryAreaDataOutput.Companion.fromRegulatoryAreaEntity
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.outputs.reportings.ReportingDataOutput
-import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.outputs.vigilanceArea.VigilanceAreaDataOutput
+import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.outputs.vigilanceArea.VigilanceAreasDataOutput
 
 class ExtractedAreaDataOutput(
     val inseeCode: String?,
     val reportings: List<ReportingDataOutput>,
     val regulatoryAreas: List<RegulatoryAreaDataOutput>,
     val amps: List<AMPDataOutput>,
-    val vigilanceAreas: List<VigilanceAreaDataOutput>,
+    val vigilanceAreas: List<VigilanceAreasDataOutput>,
 ) {
     companion object {
         fun fromExtractAreaEntity(extractedAreaEntity: ExtractedAreaEntity): ExtractedAreaDataOutput {
@@ -20,7 +20,12 @@ class ExtractedAreaDataOutput(
                 reportings = extractedAreaEntity.reportings.map { ReportingDataOutput.fromReportingDTO(it) },
                 regulatoryAreas = extractedAreaEntity.regulatoryAreas.map { fromRegulatoryAreaEntity(it) },
                 amps = extractedAreaEntity.amps.map { fromAMPEntity(it) },
-                vigilanceAreas = extractedAreaEntity.vigilanceAreas.map { VigilanceAreaDataOutput.fromVigilanceArea(it) },
+                vigilanceAreas =
+                extractedAreaEntity.vigilanceAreas.map {
+                    VigilanceAreasDataOutput.fromVigilanceArea(
+                        it,
+                    )
+                },
             )
         }
     }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/VigilanceAreaModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/VigilanceAreaModel.kt
@@ -18,6 +18,12 @@ import java.time.Instant
 import java.time.ZoneOffset.UTC
 
 @Entity
+@NamedEntityGraph(
+    name = "VigilanceAreaModel.fullLoad",
+    attributeNodes = [
+        NamedAttributeNode("images", subgraph = "subgraph.images"),
+    ],
+)
 @Table(name = "vigilance_areas")
 data class VigilanceAreaModel(
     @Id

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/VigilanceAreaModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/model/VigilanceAreaModel.kt
@@ -21,7 +21,7 @@ import java.time.ZoneOffset.UTC
 @NamedEntityGraph(
     name = "VigilanceAreaModel.fullLoad",
     attributeNodes = [
-        NamedAttributeNode("images", subgraph = "subgraph.images"),
+        NamedAttributeNode("images"),
     ],
 )
 @Table(name = "vigilance_areas")

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/interfaces/IDBVigilanceAreaRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/interfaces/IDBVigilanceAreaRepository.kt
@@ -2,6 +2,7 @@ package fr.gouv.cacem.monitorenv.infrastructure.database.repositories.interfaces
 
 import fr.gouv.cacem.monitorenv.infrastructure.database.model.VigilanceAreaModel
 import org.locationtech.jts.geom.Geometry
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -10,7 +11,7 @@ interface IDBVigilanceAreaRepository : JpaRepository<VigilanceAreaModel, Int> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
         value =
-        """
+            """
         UPDATE vigilance_areas
         SET is_deleted = TRUE
         WHERE id = :id
@@ -24,7 +25,7 @@ interface IDBVigilanceAreaRepository : JpaRepository<VigilanceAreaModel, Int> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
         value =
-        """
+            """
         UPDATE vigilance_areas
         SET is_archived = TRUE
         WHERE computed_end_date IS NOT NULL AND computed_end_date < NOW() AND is_archived IS FALSE
@@ -33,13 +34,13 @@ interface IDBVigilanceAreaRepository : JpaRepository<VigilanceAreaModel, Int> {
     )
     fun archiveOutdatedVigilanceAreas(): Int
 
+    @EntityGraph(value = "VigilanceAreaModel.fullLoad", type = EntityGraph.EntityGraphType.LOAD)
     @Query(
         value =
-        """
-            SELECT * FROM vigilance_areas
-            WHERE ST_INTERSECTS(st_setsrid(geom, 4326), st_setsrid(:geometry, 4326))
+            """
+            SELECT vigilanceArea FROM VigilanceAreaModel vigilanceArea
+            WHERE ST_INTERSECTS(st_setsrid(vigilanceArea.geom, 4326), st_setsrid(:geometry, 4326))
         """,
-        nativeQuery = true,
     )
     fun findAllByGeom(geometry: Geometry): List<VigilanceAreaModel>
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaVigilanceAreaRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaVigilanceAreaRepositoryITests.kt
@@ -1,23 +1,40 @@
 package fr.gouv.cacem.monitorenv.infrastructure.database.repositories
 
+import fr.gouv.cacem.monitorenv.config.CustomQueryCountListener
+import fr.gouv.cacem.monitorenv.config.DataSourceProxyBeanPostProcessor
 import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.*
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.io.WKTReader
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
 import org.springframework.transaction.annotation.Transactional
 import java.time.ZonedDateTime
 
+@Import(DataSourceProxyBeanPostProcessor::class)
 class JpaVigilanceAreaRepositoryITests : AbstractDBTests() {
     @Autowired
+    private val customQueryCountListener: CustomQueryCountListener? = null
+
+    @Autowired
     private lateinit var jpaVigilanceAreaRepository: JpaVigilanceAreaRepository
+
+    @BeforeEach
+    fun setUp() {
+        customQueryCountListener!!.resetQueryCount() // Reset the count before each test
+    }
 
     @Test
     @Transactional
     fun `findAll Should return all vigilance areas`() {
         // When
         val vigilanceAreas = jpaVigilanceAreaRepository.findAll()
+
+        val queryCount = customQueryCountListener?.getQueryCount()
+        println("Number of Queries Executed: $queryCount")
+
         // Then
         assertThat(vigilanceAreas.size).isEqualTo(9)
     }
@@ -63,15 +80,15 @@ class JpaVigilanceAreaRepositoryITests : AbstractDBTests() {
                 frequency = FrequencyEnum.ALL_WEEKS,
                 endDatePeriod = ZonedDateTime.parse("2024-08-08T23:59:59Z"),
                 geom = null,
-                images = listOf(
-                    ImageEntity(
-                        content = byteArrayOf(1, 2, 3, 4),
-                        mimeType = "image/jpeg",
-                        name = "test_image.jpg",
-                        size = 1024,
+                images =
+                    listOf(
+                        ImageEntity(
+                            content = byteArrayOf(1, 2, 3, 4),
+                            mimeType = "image/jpeg",
+                            name = "test_image.jpg",
+                            size = 1024,
+                        ),
                     ),
-
-                ),
                 links = null,
                 source = "Source de la zone de vigilance",
                 startDatePeriod = ZonedDateTime.parse("2024-08-18T00:00:00Z"),
@@ -175,6 +192,9 @@ class JpaVigilanceAreaRepositoryITests : AbstractDBTests() {
 
         // When
         val vigilanceAreas = jpaVigilanceAreaRepository.findAllByGeometry(polygon)
+
+        val queryCount = customQueryCountListener?.getQueryCount()
+        println("Number of Queries Executed: $queryCount")
 
         // Then
         assertThat(vigilanceAreas).hasSize(1)

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/ImageViewer.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/ImageViewer.tsx
@@ -1,6 +1,7 @@
 import { useEscapeKey } from '@hooks/useEscapeKey'
 import { Accent, Icon, IconButton, THEME } from '@mtes-mct/monitor-ui'
 import { useCallback, useState } from 'react'
+import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 
 interface ImageViewerProps {
@@ -29,7 +30,7 @@ export function ImageViewer({ currentIndex, images, onClose }: ImageViewerProps)
     onEscape: () => onClose()
   })
 
-  return (
+  return createPortal(
     <>
       <Wrapper>
         <CloseButton>
@@ -72,7 +73,8 @@ export function ImageViewer({ currentIndex, images, onClose }: ImageViewerProps)
         )}
       </Wrapper>
       <Background />
-    </>
+    </>,
+    document.body as HTMLElement
   )
 }
 

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/PhotoUploader.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/PhotoUploader.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components'
 import { ImageViewer } from './ImageViewer'
 import { getImages } from './utils'
 
-const IMAGES_INFORMATIONS_TEXT = '5 photos maximum'
+const IMAGES_INFORMATIONS_TEXT = '5 photos maximum. Formats autorisés: jpeg, png, webp'
 const IMAGES_INFORMATIONS_LIMIT_MAX_ERROR = "Vous avez atteint le nombre maximum d'images"
 const IMAGES_INFORMATIONS_REACHED_LIMIT_ERROR = 'Vous ne pouvez charger que 5 images au total'
 
@@ -163,7 +163,14 @@ export function PhotoUploaderWithRef(_, ref) {
     <div>
       <Label>Image</Label>
 
-      <input ref={ref} accept="image/*" hidden multiple onChange={uploadImageDisplay} type="file" />
+      <input
+        ref={ref}
+        accept="image/png, image/jpeg, image/webp"
+        hidden
+        multiple
+        onChange={uploadImageDisplay}
+        type="file"
+      />
       <Button
         accent={Accent.SECONDARY}
         disabled={imagesList.length >= 5}
@@ -225,7 +232,7 @@ const PreviewList = styled.ul`
 
 const PreviewImagesContainer = styled.li`
   position: relative;
-  > img {
+  > button > img {
     object-fit: cover;
   }
 `
@@ -245,6 +252,10 @@ const StyledButton = styled(Button)`
   right: 4px;
   > span {
     margin-right: 0px !important;
+    > svg {
+      height: 16px;
+      width: 16px;
+    }
   }
 `
 

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/VigilanceAreaPanel.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/VigilanceAreaPanel.tsx
@@ -284,7 +284,7 @@ const ImageContainer = styled.div`
   gap: 4px;
   padding: 16px;
   border-bottom: 1px solid ${p => p.theme.color.lightGray};
-  > img {
+  > button > img {
     object-fit: cover;
   }
 `

--- a/frontend/src/features/layersSelector/index.tsx
+++ b/frontend/src/features/layersSelector/index.tsx
@@ -166,6 +166,7 @@ const MetadataPanelShifter = styled.div<{
   opacity: ${props => (props.metadataPanelIsOpen ? 1 : 0)};
   background: ${p => p.theme.color.gainsboro};
   transition: 0.5s all;
+  z-index: -1;
 `
 
 const VigilanceAreaPanelShifter = styled.div<{
@@ -188,6 +189,7 @@ const VigilanceAreaPanelShifter = styled.div<{
   opacity: ${props => (props.isVigilanceAreaFormOpen ? 1 : 0)};
   background: ${p => p.theme.color.gainsboro};
   transition: 0.5s all;
+  z-index: -1;
 `
 
 const Sidebar = styled.div<{ isLayersSidebarVisible: boolean; isVisible: boolean }>`


### PR DESCRIPTION
- Résolution du souci de z-index
- Prise en compte des retours d'Adeline (voir ticket)
- Amélioration des perfs grâce à l'EntiyGraph + on ne renvoie plus les images dans l'api qui récupère les zones de vigilances depuis une zone dessinée

## Related Pull Requests & Issues

- Resolve #1643


----

- [ ] Tests E2E (Cypress)
