### PR TITLE
[Zones de vigilance] Ajout des filtres sur la vue liste

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IVigilanceAreaRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/repositories/IVigilanceAreaRepository.kt
@@ -15,4 +15,6 @@ interface IVigilanceAreaRepository {
     fun archiveOutdatedVigilanceAreas(): Int
 
     fun findAllIdsByGeometry(geometry: Geometry): List<Int>
+
+    fun findAllTrigrams(): List<String>
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/vigilanceArea/GetTrigrams.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/vigilanceArea/GetTrigrams.kt
@@ -1,0 +1,11 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea
+
+import fr.gouv.cacem.monitorenv.config.UseCase
+import fr.gouv.cacem.monitorenv.domain.repositories.IVigilanceAreaRepository
+
+@UseCase
+class GetTrigrams(private val vigilanceAreaRepository: IVigilanceAreaRepository) {
+    fun execute(): List<String> {
+        return vigilanceAreaRepository.findAllTrigrams()
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/v1/VigilanceAreas.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/v1/VigilanceAreas.kt
@@ -1,9 +1,6 @@
 package fr.gouv.cacem.monitorenv.infrastructure.api.endpoints.bff.v1
 
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.CreateOrUpdateVigilanceArea
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.DeleteVigilanceArea
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.GetVigilanceAreaById
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.GetVigilanceAreas
+import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.*
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.inputs.vigilanceArea.VigilanceAreaDataInput
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.outputs.vigilanceArea.VigilanceAreaDataOutput
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.outputs.vigilanceArea.VigilanceAreasDataOutput
@@ -21,6 +18,7 @@ class VigilanceAreas(
     private val createOrUpdateVigilanceArea: CreateOrUpdateVigilanceArea,
     private val getVigilanceAreaById: GetVigilanceAreaById,
     private val deleteVigilanceArea: DeleteVigilanceArea,
+    private val getTrigrams: GetTrigrams,
 ) {
     @PutMapping("", consumes = ["application/json"])
     @Operation(summary = "Create a new vigilance area")
@@ -76,5 +74,11 @@ class VigilanceAreas(
         id: Int,
     ) {
         deleteVigilanceArea.execute(id = id)
+    }
+
+    @GetMapping("/trigrams")
+    @Operation(summary = "List vigilance areas trigrams")
+    fun getTrigrams(): List<String> {
+        return getTrigrams.execute()
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaVigilanceAreaRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaVigilanceAreaRepository.kt
@@ -64,4 +64,9 @@ class JpaVigilanceAreaRepository(
     override fun archiveOutdatedVigilanceAreas(): Int {
         return dbVigilanceAreaRepository.archiveOutdatedVigilanceAreas()
     }
+
+    @Transactional
+    override fun findAllTrigrams(): List<String> {
+        return dbVigilanceAreaRepository.findAllTrigrams()
+    }
 }

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/interfaces/IDBVigilanceAreaRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/interfaces/IDBVigilanceAreaRepository.kt
@@ -41,4 +41,13 @@ interface IDBVigilanceAreaRepository : JpaRepository<VigilanceAreaModel, Int> {
         """,
     )
     fun findAllIdsByGeom(geometry: Geometry): List<Int>
+
+    @Query(
+        value =
+            """
+            SELECT DISTINCT vigilanceArea.createdBy FROM VigilanceAreaModel vigilanceArea
+            WHERE vigilanceArea.createdBy IS NOT NULL
+        """,
+    )
+    fun findAllTrigrams(): List<String>
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/vigilanceArea/GetTrigramsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/vigilanceArea/GetTrigramsUTests.kt
@@ -1,0 +1,30 @@
+package fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea
+
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import fr.gouv.cacem.monitorenv.domain.repositories.IVigilanceAreaRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GetTrigramsUTests {
+    private val vigilanceAreaRepository: IVigilanceAreaRepository = mock()
+
+    @Test
+    fun `execute should return all trigrams`() {
+        val trigrams = listOf("ABC", "DEF", "GHI")
+
+        given(vigilanceAreaRepository.findAllTrigrams()).willReturn(trigrams)
+
+        val result = GetTrigrams(vigilanceAreaRepository).execute()
+
+        assertThat(trigrams).isEqualTo(result)
+    }
+
+    @Test
+    fun `execute should return empty list if no trigrams`() {
+        given(vigilanceAreaRepository.findAllTrigrams()).willReturn(emptyList())
+
+        val result = GetTrigrams(vigilanceAreaRepository).execute()
+        assertThat(emptyList<String>()).isEqualTo(result)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/v1/VigilanceAreasITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/endpoints/bff/v1/VigilanceAreasITests.kt
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import fr.gouv.cacem.monitorenv.config.MapperConfiguration
 import fr.gouv.cacem.monitorenv.config.SentryConfig
 import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.*
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.CreateOrUpdateVigilanceArea
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.DeleteVigilanceArea
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.GetVigilanceAreaById
-import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.GetVigilanceAreas
+import fr.gouv.cacem.monitorenv.domain.use_cases.vigilanceArea.*
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.inputs.vigilanceArea.ImageDataInput
 import fr.gouv.cacem.monitorenv.infrastructure.api.adapters.bff.inputs.vigilanceArea.VigilanceAreaDataInput
 import org.hamcrest.Matchers.equalTo
@@ -46,6 +43,9 @@ class VigilanceAreasITests {
 
     @MockBean
     private lateinit var deleteVigilanceArea: DeleteVigilanceArea
+
+    @MockBean
+    private lateinit var getTrigrams: GetTrigrams
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
@@ -349,5 +349,19 @@ class VigilanceAreasITests {
         mockMvc.perform(delete("/bff/v1/vigilance_areas/$vigilanceAreaId"))
             // Then
             .andExpect(status().isNoContent())
+    }
+
+    @Test
+    fun `Should getTrigrams for vigilance areas`() {
+        // Given
+        val trigrams = listOf("ABC", "DEF", "GHI")
+        given(getTrigrams.execute()).willReturn(trigrams)
+        // When
+        mockMvc.perform(get("/bff/v1/vigilance_areas/trigrams"))
+            // Then
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0]", equalTo("ABC")))
+            .andExpect(jsonPath("$[1]", equalTo("DEF")))
+            .andExpect(jsonPath("$[2]", equalTo("GHI")))
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaVigilanceAreaRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaVigilanceAreaRepositoryITests.kt
@@ -2,11 +2,7 @@ package fr.gouv.cacem.monitorenv.infrastructure.database.repositories
 
 import fr.gouv.cacem.monitorenv.config.CustomQueryCountListener
 import fr.gouv.cacem.monitorenv.config.DataSourceProxyBeanPostProcessor
-import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.EndingConditionEnum
-import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.FrequencyEnum
-import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.ImageEntity
-import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.VigilanceAreaEntity
-import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.VisibilityEnum
+import fr.gouv.cacem.monitorenv.domain.entities.vigilanceArea.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -203,5 +199,14 @@ class JpaVigilanceAreaRepositoryITests : AbstractDBTests() {
         // Then
         assertThat(vigilanceAreas).hasSize(1)
         assertThat(vigilanceAreas[0]).isEqualTo(8)
+    }
+
+    @Test
+    fun `findAllTrigrams should return all vigilance areas trigrams`() {
+        // When
+        val trigrams = jpaVigilanceAreaRepository.findAllTrigrams()
+
+        // Then
+        assertThat(trigrams).hasSize(4)
     }
 }

--- a/frontend/cypress/e2e/main_window/layerTree/amp_layers.spec.ts
+++ b/frontend/cypress/e2e/main_window/layerTree/amp_layers.spec.ts
@@ -8,7 +8,6 @@ context('LayerTree > AMP Layers', () => {
     cy.clickButton('Arbre des couches').wait(1000)
   })
   it('An AMP Should be searched, added to My Zones and showed on the map with the Zone button', () => {
-    cy.clickButton('Filtrer par type de zones').wait(1000)
     cy.fill("Type d'AMP", ['Natura 2000'])
     cy.getDataCy('amp-results-list-button').click()
     cy.getDataCy('amp-result-list').find('li').first().click()

--- a/frontend/cypress/e2e/main_window/layerTree/vigilance_area_layers.spec.ts
+++ b/frontend/cypress/e2e/main_window/layerTree/vigilance_area_layers.spec.ts
@@ -17,6 +17,7 @@ context('LayerTree > Vigilance Area Layers', () => {
     cy.clickButton('Définir la zone de recherche et afficher les tracés')
 
     cy.fill('Rechercher une zone', 'Lorem ipsum') // "Lorem ipsum" is in comments of vigilance area
+    cy.fill('Période de vigilance', 'Cette année')
     cy.getDataCy('vigilance-area-results-list-button').contains('1 résultat').click()
 
     cy.getDataCy('vigilance-area-result-zone').contains('Zone de vigilance 4').click()
@@ -44,10 +45,7 @@ context('LayerTree > Vigilance Area Layers', () => {
   })
 
   it('A vigilance area should be searched per period', () => {
-    cy.clickButton('Filtrer par type de zones')
-
     // Filter "Next three months"
-    cy.fill('Période de vigilance', 'Les trois prochains mois')
     cy.getDataCy('vigilance-area-results-list-button').click()
     cy.getDataCy('vigilance-area-result-zone').contains('Zone de vigilance 1')
     cy.getDataCy('vigilance-area-result-zone').contains('Zone de vigilance 2')
@@ -78,11 +76,11 @@ context('LayerTree > Vigilance Area Layers', () => {
     cy.getDataCy('vigilance-area-result-zone').contains('Zone de vigilance 8')
   })
   it('Result list should be displayed by default but not checked and total should be visible', () => {
-    cy.getDataCy('vigilance-area-results-list-button').contains('9 résultats')
+    cy.getDataCy('vigilance-area-results-list-button').contains('5 résultats')
 
     cy.get('#isVigilanceAreaSearchResultsVisible').should('not.be.checked')
     cy.getDataCy('vigilance-area-results-list-button').click()
-    cy.getDataCy('vigilance-area-result-list').children().should('have.length', 9)
+    cy.getDataCy('vigilance-area-result-list').children().should('have.length', 5)
     cy.get('#isVigilanceAreaSearchResultsVisible').should('be.checked')
   })
 })

--- a/frontend/cypress/e2e/main_window/vigilance_area/edit_vigilance_area.spec.ts
+++ b/frontend/cypress/e2e/main_window/vigilance_area/edit_vigilance_area.spec.ts
@@ -9,6 +9,7 @@ describe('Edit Vigilance Area', () => {
   it('Should successfully update a vigilance area', () => {
     cy.visit('/#@-192242.97,5819420.73,9.93')
     cy.wait(1000)
+    cy.clickButton('Arbre des couches')
     cy.clickButton('Définir la zone de recherche et afficher les tracés')
     cy.wait(1000)
 
@@ -45,6 +46,7 @@ describe('Edit Vigilance Area', () => {
   it('Should successfully add regulatory area to a vigilance area and consult them', () => {
     cy.visit('/#@-668012.81,6169323.28,8.44')
     cy.wait(1000)
+    cy.clickButton('Arbre des couches')
     cy.clickButton('Définir la zone de recherche et afficher les tracés')
     cy.wait(1000)
 
@@ -55,7 +57,6 @@ describe('Edit Vigilance Area', () => {
     cy.clickButton('Editer')
 
     cy.clickButton('Ajouter une réglementation en lien')
-    cy.clickButton('Arbre des couches')
     cy.getDataCy('my-amp-layers-zones').should('not.exist')
     cy.clickButton('Filtrer par type de zones')
     cy.fill('Thématique réglementaire', ['AMP', 'Dragage', 'Mixte'])
@@ -97,6 +98,7 @@ describe('Edit Vigilance Area', () => {
   it('Should successfully add AMP to a vigilance area and consult them', () => {
     cy.visit('/#@-181811.71,5844094.04,9.31')
     cy.wait(1000)
+    cy.clickButton('Arbre des couches')
     cy.clickButton('Définir la zone de recherche et afficher les tracés')
     cy.wait(1000)
 
@@ -107,7 +109,6 @@ describe('Edit Vigilance Area', () => {
     cy.clickButton('Editer')
 
     cy.clickButton('Ajouter une AMP en lien')
-    cy.clickButton('Arbre des couches')
     cy.getDataCy('my-regulatory-layers').should('not.exist')
     cy.clickButton('Filtrer par type de zones')
     cy.fill("Type d'AMP", ['Natura 2000'])

--- a/frontend/cypress/e2e/side_window/vigilance_areas_list/filters.spec.ts
+++ b/frontend/cypress/e2e/side_window/vigilance_areas_list/filters.spec.ts
@@ -9,84 +9,50 @@ context('Side Window > Vigilance Areas List > Filter Bar', () => {
     cy.getDataCy('reinitialize-filters').scrollIntoView().click()
   })
 
+  const verifyVigilanceAreaRows = (expectedText: string) => {
+    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
+    cy.getDataCy('vigilance-area-row').each((row, index) => {
+      if (index === 0) {
+        return
+      }
+      cy.wrap(row).should('contain', expectedText)
+    })
+  }
+
   it('Should filter vigilance areas for the current year', () => {
     cy.fill('Période de vigilance', 'Cette année')
-
     cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
   })
 
   it('Should filter vigilance areas by themes filter', () => {
     cy.wait(500)
     cy.fill('Thématique réglementaire', ['Dragage'])
-
     cy.getDataCy('vigilance-areas-filter-tags').find('.Component-SingleTag > span').contains('Dragage')
-    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
-    cy.getDataCy('vigilance-area-row').each((row, index) => {
-      if (index === 0) {
-        return
-      }
-
-      cy.wrap(row).should('contain', 'Dragage')
-    })
+    verifyVigilanceAreaRows('Dragage')
   })
 
   it('Should filter vigilance areas by createdBy filter', () => {
     cy.fill('Zone créée par...', ['ABC'])
-
-    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
-    cy.getDataCy('vigilance-area-row').each((row, index) => {
-      if (index === 0) {
-        return
-      }
-
-      cy.wrap(row).should('contain', 'ABC')
-    })
+    verifyVigilanceAreaRows('ABC')
   })
 
   it('Should filter missions by seaFront filter', () => {
     cy.fill('Façade', ['NAMO'])
-
-    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
-    cy.getDataCy('vigilance-area-row').each((row, index) => {
-      if (index === 0) {
-        return
-      }
-
-      cy.wrap(row).should('contain', 'NAMO')
-    })
+    verifyVigilanceAreaRows('NAMO')
   })
 
   it('Should filter missions by draft status', () => {
-    // uncheck published status
     cy.fill('Publiée', false)
-
-    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
-    cy.getDataCy('vigilance-area-row').each((row, index) => {
-      if (index === 0) {
-        return
-      }
-
-      cy.wrap(row).should('contain', 'Non Publiée')
-    })
+    verifyVigilanceAreaRows('Non Publiée')
   })
 
   it('Should filter missions by published status', () => {
-    // uncheck draft status
     cy.fill('Non publiée', false)
-
-    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
-    cy.getDataCy('vigilance-area-row').each((row, index) => {
-      if (index === 0) {
-        return
-      }
-
-      cy.wrap(row).should('contain', 'Publiée')
-    })
+    verifyVigilanceAreaRows('Publiée')
   })
 
   it('Should filter missions by search query', () => {
     cy.fill('Rechercher dans les zones de vigilance', 'Proin')
-
     cy.getDataCy('vigilance-area-row').should('have.length', 1)
   })
 })

--- a/frontend/cypress/e2e/side_window/vigilance_areas_list/filters.spec.ts
+++ b/frontend/cypress/e2e/side_window/vigilance_areas_list/filters.spec.ts
@@ -1,0 +1,92 @@
+context('Side Window > Vigilance Areas List > Filter Bar', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 1024)
+    cy.visit(`/side_window`).wait(1000)
+    cy.clickButton('Zones de vigilance')
+  })
+
+  afterEach(() => {
+    cy.getDataCy('reinitialize-filters').scrollIntoView().click()
+  })
+
+  it('Should filter vigilance areas for the current year', () => {
+    cy.fill('Période de vigilance', 'Cette année')
+
+    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
+  })
+
+  it('Should filter vigilance areas by themes filter', () => {
+    cy.wait(500)
+    cy.fill('Thématique réglementaire', ['Dragage'])
+
+    cy.getDataCy('vigilance-areas-filter-tags').find('.Component-SingleTag > span').contains('Dragage')
+    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
+    cy.getDataCy('vigilance-area-row').each((row, index) => {
+      if (index === 0) {
+        return
+      }
+
+      cy.wrap(row).should('contain', 'Dragage')
+    })
+  })
+
+  it('Should filter vigilance areas by createdBy filter', () => {
+    cy.fill('Zone créée par...', ['ABC'])
+
+    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
+    cy.getDataCy('vigilance-area-row').each((row, index) => {
+      if (index === 0) {
+        return
+      }
+
+      cy.wrap(row).should('contain', 'ABC')
+    })
+  })
+
+  it('Should filter missions by seaFront filter', () => {
+    cy.fill('Façade', ['NAMO'])
+
+    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
+    cy.getDataCy('vigilance-area-row').each((row, index) => {
+      if (index === 0) {
+        return
+      }
+
+      cy.wrap(row).should('contain', 'NAMO')
+    })
+  })
+
+  it('Should filter missions by draft status', () => {
+    // uncheck published status
+    cy.fill('Publiée', false)
+
+    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
+    cy.getDataCy('vigilance-area-row').each((row, index) => {
+      if (index === 0) {
+        return
+      }
+
+      cy.wrap(row).should('contain', 'Non Publiée')
+    })
+  })
+
+  it('Should filter missions by published status', () => {
+    // uncheck draft status
+    cy.fill('Non publiée', false)
+
+    cy.getDataCy('vigilance-area-row').should('have.length.to.be.greaterThan', 0)
+    cy.getDataCy('vigilance-area-row').each((row, index) => {
+      if (index === 0) {
+        return
+      }
+
+      cy.wrap(row).should('contain', 'Publiée')
+    })
+  })
+
+  it('Should filter missions by search query', () => {
+    cy.fill('Rechercher dans les zones de vigilance', 'Proin')
+
+    cy.getDataCy('vigilance-area-row').should('have.length', 1)
+  })
+})

--- a/frontend/src/api/vigilanceAreasAPI.ts
+++ b/frontend/src/api/vigilanceAreasAPI.ts
@@ -27,6 +27,9 @@ export const vigilanceAreasAPI = monitorenvPrivateApi.injectEndpoints({
         url: `/v1/vigilance_areas/${id}`
       })
     }),
+    getTrigrams: build.query<string[], void>({
+      query: () => '/v1/vigilance_areas/trigrams'
+    }),
     getVigilanceArea: build.query<VigilanceArea.VigilanceArea, number>({
       providesTags: (_, __, id) => [{ id, type: 'VigilanceAreas' }],
       query: id => `/v1/vigilance_areas/${id}`
@@ -65,6 +68,7 @@ export const vigilanceAreasAPI = monitorenvPrivateApi.injectEndpoints({
 
 export const {
   useCreateVigilanceAreaMutation,
+  useGetTrigramsQuery,
   useGetVigilanceAreaQuery,
   useGetVigilanceAreasQuery,
   useUpdateVigilanceAreaMutation

--- a/frontend/src/api/vigilanceAreasAPI.ts
+++ b/frontend/src/api/vigilanceAreasAPI.ts
@@ -33,7 +33,7 @@ export const vigilanceAreasAPI = monitorenvPrivateApi.injectEndpoints({
     }),
     getVigilanceAreas: build.query<EntityState<VigilanceArea.VigilanceAreaLayer, number>, void>({
       providesTags: () => [{ id: 'LIST', type: 'VigilanceAreas' } as const],
-      query: () => `/v1/vigilance_areas`,
+      query: () => '/v1/vigilance_areas',
       transformResponse: (response: VigilanceArea.VigilanceAreaLayer[]) =>
         VigilanceAreaLayersAdapter.setAll(
           vigilanceAreaLayersInitialState,

--- a/frontend/src/components/RegulatoryThemesFilter.tsx
+++ b/frontend/src/components/RegulatoryThemesFilter.tsx
@@ -46,6 +46,7 @@ export function RegulatoryThemesFilter({ style }: { style?: React.CSSProperties 
 
   return (
     <CheckPicker
+      key={String(regulatoryThemes.length)}
       customSearch={regulatoryThemesCustomSearch}
       isLabelHidden
       isTransparent

--- a/frontend/src/components/RegulatoryThemesFilter.tsx
+++ b/frontend/src/components/RegulatoryThemesFilter.tsx
@@ -1,0 +1,66 @@
+import { useGetRegulatoryLayersQuery } from '@api/regulatoryLayersAPI'
+import { useSearchLayers } from '@features/layersSelector/search/hooks/useSearchLayers'
+import { setFilteredRegulatoryThemes } from '@features/layersSelector/search/slice'
+import { OptionValue } from '@features/Reportings/Filters/style'
+import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { CheckPicker, CustomSearch, type Option } from '@mtes-mct/monitor-ui'
+import { getRegulatoryThemesAsOptions } from '@utils/getRegulatoryThemesAsOptions'
+import { useMemo } from 'react'
+
+export function RegulatoryThemesFilter({ style }: { style?: React.CSSProperties }) {
+  const dispatch = useAppDispatch()
+  const { data: regulatoryLayers } = useGetRegulatoryLayersQuery()
+
+  const regulatoryThemes = useMemo(() => getRegulatoryThemesAsOptions(regulatoryLayers ?? []), [regulatoryLayers])
+
+  const regulatoryThemesCustomSearch = useMemo(
+    () => new CustomSearch(regulatoryThemes as Array<Option<string>>, ['label']),
+    [regulatoryThemes]
+  )
+
+  const searchExtent = useAppSelector(state => state.layerSearch.searchExtent)
+  const globalSearchText = useAppSelector(state => state.layerSearch.globalSearchText)
+
+  const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
+  const filteredAmpTypes = useAppSelector(state => state.layerSearch.filteredAmpTypes)
+  const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
+  const vigilanceAreaSpecificPeriodFilter = useAppSelector(state => state.layerSearch.vigilanceAreaSpecificPeriodFilter)
+
+  const shouldFilterSearchOnMapExtent = useAppSelector(state => state.layerSearch.shouldFilterSearchOnMapExtent)
+
+  const debouncedSearchLayers = useSearchLayers()
+
+  const handleSetFilteredRegulatoryThemes = filteredThemes => {
+    dispatch(setFilteredRegulatoryThemes(filteredThemes))
+    debouncedSearchLayers({
+      ampTypes: filteredAmpTypes,
+      extent: searchExtent,
+      regulatoryThemes: filteredThemes,
+      searchedText: globalSearchText,
+      shouldSearchByExtent: shouldFilterSearchOnMapExtent,
+      vigilanceAreaPeriodFilter: filteredVigilanceAreaPeriod,
+      vigilanceAreaSpecificPeriodFilter
+    })
+  }
+
+  return (
+    <CheckPicker
+      customSearch={regulatoryThemesCustomSearch}
+      isLabelHidden
+      isTransparent
+      label="Thématique réglementaire"
+      name="regulatoryThemes"
+      onChange={handleSetFilteredRegulatoryThemes}
+      options={regulatoryThemes || []}
+      placeholder="Thématique réglementaire"
+      renderValue={() =>
+        filteredRegulatoryThemes && (
+          <OptionValue>{`Thématique réglementaire (${filteredRegulatoryThemes.length})`}</OptionValue>
+        )
+      }
+      style={style}
+      value={filteredRegulatoryThemes}
+    />
+  )
+}

--- a/frontend/src/components/Table/style.ts
+++ b/frontend/src/components/Table/style.ts
@@ -2,6 +2,6 @@ import styled from 'styled-components'
 
 export const TotalResults = styled.h2`
   font-size: 13px;
-  margin-top: 12px;
+  margin-top: 32px;
   line-height: 22px;
 `

--- a/frontend/src/components/style.ts
+++ b/frontend/src/components/style.ts
@@ -27,3 +27,24 @@ export const DialogSeparator = styled.div`
   margin-left: -12px;
   margin-right: -12px;
 `
+
+// Filters table
+export const CustomPeriodContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`
+
+export const CustomPeriodLabel = styled.div`
+  color: ${p => p.theme.color.slateGray};
+  font-size: 13px;
+`
+export const TagsContainer = styled.div<{ $withTopMargin: boolean }>`
+  align-items: end;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: ${p => (p.$withTopMargin ? '16px' : '0px')};
+  max-width: 100%;
+`

--- a/frontend/src/domain/shared_slices/LayerSidebar.ts
+++ b/frontend/src/domain/shared_slices/LayerSidebar.ts
@@ -16,7 +16,7 @@ const initialState: LayerSidebarSliceState = {
   administrativeZonesIsOpen: false,
   areAmpsResultsOpen: false,
   areMyVigilanceAreasOpen: false,
-  areRegFiltersOpen: false,
+  areRegFiltersOpen: true,
   areRegulatoryResultsOpen: false,
   baselayerIsOpen: false,
   myAmpsIsOpen: false,
@@ -34,55 +34,65 @@ export const layerSidebarSlice = createSlice({
     toggleAdministrativeZones(state) {
       return {
         ...initialState,
-        administrativeZonesIsOpen: !state.administrativeZonesIsOpen
+        administrativeZonesIsOpen: !state.administrativeZonesIsOpen,
+        areRegFiltersOpen: false
       }
     },
     toggleAmpResults(state, action: PayloadAction<boolean | undefined>) {
       return {
         ...initialState,
-        areAmpsResultsOpen: action?.payload ?? !state.areAmpsResultsOpen
+        areAmpsResultsOpen: action?.payload ?? !state.areAmpsResultsOpen,
+        areRegFiltersOpen: false
       }
     },
     toggleBaseLayer(state) {
       return {
         ...initialState,
+        areRegFiltersOpen: false,
         baselayerIsOpen: !state.baselayerIsOpen
       }
     },
     toggleMyAmps(state) {
       return {
         ...initialState,
+        areRegFiltersOpen: false,
         myAmpsIsOpen: !state.myAmpsIsOpen
       }
     },
     toggleMyRegulatoryZones(state) {
       return {
         ...initialState,
+        areRegFiltersOpen: false,
         myRegulatoryZonesIsOpen: !state.myRegulatoryZonesIsOpen
       }
     },
     toggleMyVigilanceAreas(state) {
       return {
         ...initialState,
+        areRegFiltersOpen: false,
         myVigilanceAreasIsOpen: !state.myVigilanceAreasIsOpen
       }
     },
-    toggleRegFilters(state) {
+    toggleRegFilters(state, action: PayloadAction<boolean | undefined>) {
+      const isChecked = action?.payload ?? !state.areRegFiltersOpen
+
       return {
         ...initialState,
-        areRegFiltersOpen: !state.areRegFiltersOpen
+        areRegFiltersOpen: isChecked
       }
     },
     toggleRegulatoryResults(state, action: PayloadAction<boolean | undefined>) {
       return {
         ...initialState,
+        areRegFiltersOpen: false,
         areRegulatoryResultsOpen: action?.payload ?? !state.areRegulatoryResultsOpen
       }
     },
     toggleVigilanceAreaResults(state, action: PayloadAction<boolean | undefined>) {
       return {
         ...initialState,
-        areMyVigilanceAreasOpen: action?.payload ?? !state.areMyVigilanceAreasOpen
+        areMyVigilanceAreasOpen: action?.payload ?? !state.areMyVigilanceAreasOpen,
+        areRegFiltersOpen: false
       }
     }
   }

--- a/frontend/src/features/Dashboard/components/DashboardForm/Reportings/Filters.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardForm/Reportings/Filters.tsx
@@ -1,5 +1,6 @@
+import { CustomPeriodContainer } from '@components/style'
 import { getFilteredReportings } from '@features/Dashboard/slice'
-import { StyledCustomPeriodContainer, StyledSelect } from '@features/Reportings/Filters/style'
+import { StyledSelect } from '@features/Reportings/Filters/style'
 import { useAppDispatch } from '@hooks/useAppDispatch'
 import { useAppSelector } from '@hooks/useAppSelector'
 import {
@@ -93,7 +94,7 @@ export const Filters = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ ...p
           value={reportingFilters.dateRange}
         />
         {reportingFilters.dateRange === ReportingDateRangeEnum.CUSTOM && (
-          <StyledCustomPeriodContainer>
+          <CustomPeriodContainer>
             <DateRangePicker
               key="dateRange"
               baseContainer={newWindowContainerRef.current}
@@ -104,7 +105,7 @@ export const Filters = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ ...p
               name="dateRange"
               onChange={setCustomPeriodFilter}
             />
-          </StyledCustomPeriodContainer>
+          </CustomPeriodContainer>
         )}
       </StyledDatesWrapper>
 

--- a/frontend/src/features/Dashboard/components/DashboardForm/Toolbar/Filters/index.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardForm/Toolbar/Filters/index.tsx
@@ -1,3 +1,4 @@
+import { CustomPeriodContainer, CustomPeriodLabel } from '@components/style'
 import { ReinitializeFiltersButton } from '@features/commonComponents/ReinitializeFiltersButton'
 import { type DashboardType } from '@features/Dashboard/slice'
 import { VigilanceArea } from '@features/VigilanceArea/types'
@@ -137,8 +138,8 @@ export function DashboardFilters({ dashboard }: FiltersProps) {
       {(hasFilters || filters?.specificPeriod) && (
         <TagsContainer data-cy="dashboard-filter-tags">
           {filters?.vigilanceAreaPeriod === VigilanceArea.VigilanceAreaFilterPeriod.SPECIFIC_PERIOD && (
-            <StyledCustomPeriodContainer>
-              <StyledCutomPeriodLabel>Période spécifique</StyledCutomPeriodLabel>
+            <CustomPeriodContainer>
+              <CustomPeriodLabel>Période spécifique</CustomPeriodLabel>
               <DateRangePicker
                 key="dateRange"
                 defaultValue={filters?.specificPeriod ?? undefined}
@@ -148,7 +149,7 @@ export function DashboardFilters({ dashboard }: FiltersProps) {
                 name="dateRange"
                 onChange={updateDateRangeFilter}
               />
-            </StyledCustomPeriodContainer>
+            </CustomPeriodContainer>
           )}
           {filters?.regulatoryThemes?.map(theme => (
             <SingleTag key={theme} onDelete={() => deleteRegulatoryTheme(theme)} title={theme}>
@@ -191,15 +192,7 @@ const TagsContainer = styled.div`
   flex: 0 1 50%;
   gap: 16px;
 `
-export const StyledCustomPeriodContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-`
-export const StyledCutomPeriodLabel = styled.div`
-  color: ${p => p.theme.color.slateGray};
-  font-size: 13px;
-`
+
 const StyledButton = styled.button`
   background-color: ${p => p.theme.color.white};
   color: ${p => p.theme.color.slateGray};

--- a/frontend/src/features/Reportings/Filters/Map/index.tsx
+++ b/frontend/src/features/Reportings/Filters/Map/index.tsx
@@ -1,3 +1,4 @@
+import { CustomPeriodContainer } from '@components/style'
 import { CheckPicker, DateRangePicker, Checkbox, SingleTag } from '@mtes-mct/monitor-ui'
 import { ReportingDateRangeEnum } from 'domain/entities/dateRange'
 import { forwardRef } from 'react'
@@ -260,10 +261,7 @@ const FilterWrapper = styled.div`
   flex-direction: column;
   padding: 12px 4px;
 `
-export const StyledCustomPeriodContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+export const StyledCustomPeriodContainer = styled(CustomPeriodContainer)`
   align-items: start;
   text-align: left;
 `

--- a/frontend/src/features/Reportings/Filters/Table/index.tsx
+++ b/frontend/src/features/Reportings/Filters/Table/index.tsx
@@ -1,3 +1,4 @@
+import { CustomPeriodContainer, CustomPeriodLabel } from '@components/style'
 import { ReinitializeFiltersButton } from '@features/commonComponents/ReinitializeFiltersButton'
 import { CheckPicker, DateRangePicker, Checkbox, CustomSearch, type Option, useNewWindow } from '@mtes-mct/monitor-ui'
 import { ReportingDateRangeEnum } from 'domain/entities/dateRange'
@@ -9,15 +10,7 @@ import { AttachToMissionFilterEnum, AttachToMissionFilterLabels } from '../../..
 import { ReportingsFiltersEnum } from '../../../../domain/shared_slices/ReportingsFilters'
 import { useAppSelector } from '../../../../hooks/useAppSelector'
 import { ReportingSearch } from '../ReportingSearch'
-import {
-  OptionValue,
-  Separator,
-  StyledCustomPeriodContainer,
-  StyledCutomPeriodLabel,
-  StyledSelect,
-  StyledStatusFilter,
-  StyledTagsContainer
-} from '../style'
+import { OptionValue, Separator, StyledSelect, StyledStatusFilter, StyledTagsContainer } from '../style'
 
 export function TableReportingsFiltersWithRef(
   {
@@ -260,8 +253,8 @@ export function TableReportingsFiltersWithRef(
       </FilterWrapper>
       <StyledTagsContainer $withTopMargin={isCustomPeriodVisible || hasFilters}>
         {isCustomPeriodVisible && (
-          <StyledCustomPeriodContainer>
-            <StyledCutomPeriodLabel>Période spécifique</StyledCutomPeriodLabel>
+          <CustomPeriodContainer>
+            <CustomPeriodLabel>Période spécifique</CustomPeriodLabel>
             <DateRangePicker
               key="dateRange"
               baseContainer={newWindowContainerRef.current}
@@ -275,7 +268,7 @@ export function TableReportingsFiltersWithRef(
               name="dateRange"
               onChange={updateDateRangeFilter}
             />
-          </StyledCustomPeriodContainer>
+          </CustomPeriodContainer>
         )}
 
         <FilterTags />

--- a/frontend/src/features/Reportings/Filters/style.ts
+++ b/frontend/src/features/Reportings/Filters/style.ts
@@ -1,3 +1,4 @@
+import { TagsContainer } from '@components/style'
 import { Select } from '@mtes-mct/monitor-ui'
 import styled from 'styled-components'
 
@@ -20,24 +21,8 @@ export const StyledSelect = styled(Select)`
   }
 `
 
-export const StyledTagsContainer = styled.div<{ $withTopMargin: boolean }>`
-  align-items: end;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 16px;
-  margin-top: ${p => (p.$withTopMargin ? '16px' : '0px')};
-  max-width: 100%;
+export const StyledTagsContainer = styled(TagsContainer)`
   padding-right: 2%;
-`
-export const StyledCustomPeriodContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-`
-export const StyledCutomPeriodLabel = styled.div`
-  color: ${p => p.theme.color.slateGray};
-  font-size: 13px;
 `
 
 export const OptionValue = styled.span`

--- a/frontend/src/features/Reportings/components/ReportingsList/GroupActions.tsx
+++ b/frontend/src/features/Reportings/components/ReportingsList/GroupActions.tsx
@@ -34,9 +34,9 @@ export function GroupActions({ archiveOrDeleteReportingsCallback, reportingsIds,
           title="Supprimer"
         />
       </StyledButtonsContainer>
-      <TotalResults data-cy="totalReportings">
+      <StyledTotalResults data-cy="totalReportings">
         {totalReportings} {pluralize('Signalement', totalReportings)}
-      </TotalResults>
+      </StyledTotalResults>
     </StyledGroupActionContainer>
   )
 }
@@ -46,7 +46,7 @@ const StyledGroupActionContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
   margin-bottom: 8px;
-  margin-top: 40px;
+  margin-top: 32px;
   align-items: end;
   padding-right: 2%;
 `
@@ -54,4 +54,7 @@ const StyledButtonsContainer = styled.div`
   display: flex;
   gap: 8px;
   align-self: end;
+`
+const StyledTotalResults = styled(TotalResults)`
+  margin-top: 0px;
 `

--- a/frontend/src/features/VigilanceArea/components/PeriodFilter.tsx
+++ b/frontend/src/features/VigilanceArea/components/PeriodFilter.tsx
@@ -1,0 +1,69 @@
+import { useSearchLayers } from '@features/layersSelector/search/hooks/useSearchLayers'
+import {
+  setFilteredVigilanceAreaPeriod,
+  setVigilanceAreaSpecificPeriodFilter
+} from '@features/layersSelector/search/slice'
+import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { Select, type Option } from '@mtes-mct/monitor-ui'
+
+import { VigilanceArea } from '../types'
+
+export function PeriodFilter({ style }: { style?: React.CSSProperties }) {
+  const dispatch = useAppDispatch()
+  const vigilanceAreaPeriodOptions = Object.entries(VigilanceArea.VigilanceAreaFilterPeriodLabel).map(
+    ([value, label]) => ({ label, value })
+  ) as Option<VigilanceArea.VigilanceAreaFilterPeriod>[]
+
+  const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
+  const vigilanceAreaSpecificPeriodFilter = useAppSelector(state => state.layerSearch.vigilanceAreaSpecificPeriodFilter)
+
+  const searchExtent = useAppSelector(state => state.layerSearch.searchExtent)
+  const globalSearchText = useAppSelector(state => state.layerSearch.globalSearchText)
+
+  const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
+  const filteredAmpTypes = useAppSelector(state => state.layerSearch.filteredAmpTypes)
+
+  const shouldFilterSearchOnMapExtent = useAppSelector(state => state.layerSearch.shouldFilterSearchOnMapExtent)
+
+  const debouncedSearchLayers = useSearchLayers()
+
+  const handleSetFilteredVigilancePeriod = (
+    nextVigilanceAreaPeriod: VigilanceArea.VigilanceAreaFilterPeriod | undefined
+  ) => {
+    dispatch(setFilteredVigilanceAreaPeriod(nextVigilanceAreaPeriod))
+
+    if (nextVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.SPECIFIC_PERIOD) {
+      dispatch(setVigilanceAreaSpecificPeriodFilter(undefined))
+    }
+
+    const nextVigilanceAreaSpecificPeriodFilter =
+      nextVigilanceAreaPeriod === VigilanceArea.VigilanceAreaFilterPeriod.SPECIFIC_PERIOD
+        ? vigilanceAreaSpecificPeriodFilter
+        : undefined
+    debouncedSearchLayers({
+      ampTypes: filteredAmpTypes,
+      extent: searchExtent,
+      regulatoryThemes: filteredRegulatoryThemes,
+      searchedText: globalSearchText,
+      shouldSearchByExtent: shouldFilterSearchOnMapExtent,
+      vigilanceAreaPeriodFilter: nextVigilanceAreaPeriod,
+      vigilanceAreaSpecificPeriodFilter: nextVigilanceAreaSpecificPeriodFilter
+    })
+  }
+
+  return (
+    <Select
+      isCleanable={false}
+      isLabelHidden
+      isTransparent
+      label="Période de vigilance"
+      name="periodOfVigilanceArea"
+      onChange={handleSetFilteredVigilancePeriod}
+      options={vigilanceAreaPeriodOptions}
+      placeholder="Période de vigilance"
+      style={style}
+      value={filteredVigilanceAreaPeriod}
+    />
+  )
+}

--- a/frontend/src/features/VigilanceArea/components/SpecificPeriodFilter.tsx
+++ b/frontend/src/features/VigilanceArea/components/SpecificPeriodFilter.tsx
@@ -1,0 +1,46 @@
+import { useSearchLayers } from '@features/layersSelector/search/hooks/useSearchLayers'
+import { setVigilanceAreaSpecificPeriodFilter } from '@features/layersSelector/search/slice'
+import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { DateRangePicker, type DateAsStringRange } from '@mtes-mct/monitor-ui'
+
+export function SpecificPeriodFilter() {
+  const dispatch = useAppDispatch()
+
+  const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
+  const vigilanceAreaSpecificPeriodFilter = useAppSelector(state => state.layerSearch.vigilanceAreaSpecificPeriodFilter)
+
+  const searchExtent = useAppSelector(state => state.layerSearch.searchExtent)
+  const globalSearchText = useAppSelector(state => state.layerSearch.globalSearchText)
+
+  const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
+  const filteredAmpTypes = useAppSelector(state => state.layerSearch.filteredAmpTypes)
+
+  const shouldFilterSearchOnMapExtent = useAppSelector(state => state.layerSearch.shouldFilterSearchOnMapExtent)
+
+  const debouncedSearchLayers = useSearchLayers()
+
+  const updateDateRangeFilter = (dateRange: DateAsStringRange | undefined) => {
+    dispatch(setVigilanceAreaSpecificPeriodFilter(dateRange))
+    debouncedSearchLayers({
+      ampTypes: filteredAmpTypes,
+      extent: searchExtent,
+      regulatoryThemes: filteredRegulatoryThemes,
+      searchedText: globalSearchText,
+      shouldSearchByExtent: shouldFilterSearchOnMapExtent,
+      vigilanceAreaPeriodFilter: filteredVigilanceAreaPeriod,
+      vigilanceAreaSpecificPeriodFilter: dateRange
+    })
+  }
+
+  return (
+    <DateRangePicker
+      defaultValue={vigilanceAreaSpecificPeriodFilter as DateAsStringRange}
+      isLabelHidden
+      isStringDate
+      label="Période spécifique"
+      name="dateRange"
+      onChange={updateDateRangeFilter}
+    />
+  )
+}

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/utils.ts
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/utils.ts
@@ -18,6 +18,7 @@ export function getVigilanceAreaInitialValues(): Omit<VigilanceArea.VigilanceAre
     linkedRegulatoryAreas: [],
     links: [],
     name: undefined,
+    seaFront: undefined,
     source: undefined,
     startDatePeriod: undefined,
     themes: [],

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreaLayer/PreviewVigilanceAreasLayer.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreaLayer/PreviewVigilanceAreasLayer.tsx
@@ -1,4 +1,4 @@
-import { useGetVigilanceAreasQuery } from '@api/vigilanceAreasAPI'
+import { useGetFilteredVigilanceAreasQuery } from '@features/VigilanceArea/hooks/useGetFilteredVigilanceAreasQuery'
 import { useAppSelector } from '@hooks/useAppSelector'
 import { Layers } from 'domain/entities/layers/constants'
 import { Feature } from 'ol'
@@ -8,7 +8,6 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import { getVigilanceAreaLayerStyle } from './style'
 import { getVigilanceAreaZoneFeature } from './vigilanceAreaGeometryHelper'
-import { TWO_MINUTES } from '../../../../constants'
 
 import type { BaseMapChildrenProps } from '@features/map/BaseMap'
 import type { VectorLayerWithName } from 'domain/types/layer'
@@ -24,7 +23,7 @@ export function PreviewVigilanceAreasLayer({ map }: BaseMapChildrenProps) {
 
   const isLayerVisible = displayVigilanceAreaLayer && isVigilanceAreaSearchResultsVisible
 
-  const { data: vigilanceAreas } = useGetVigilanceAreasQuery(undefined, { pollingInterval: TWO_MINUTES })
+  const { vigilanceAreas } = useGetFilteredVigilanceAreasQuery()
 
   const vectorSourceRef = useRef(new VectorSource()) as React.MutableRefObject<VectorSource<Feature<Geometry>>>
   const vectorLayerRef = useRef(

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreaLayer/PreviewVigilanceAreasLayer.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreaLayer/PreviewVigilanceAreasLayer.tsx
@@ -20,8 +20,8 @@ export function PreviewVigilanceAreasLayer({ map }: BaseMapChildrenProps) {
   const isVigilanceAreaSearchResultsVisible = useAppSelector(
     state => state.layerSearch.isVigilanceAreaSearchResultsVisible
   )
-
-  const isLayerVisible = displayVigilanceAreaLayer && isVigilanceAreaSearchResultsVisible
+  const isLayersSidebarVisible = useAppSelector(state => state.global.isLayersSidebarVisible)
+  const isLayerVisible = displayVigilanceAreaLayer && isVigilanceAreaSearchResultsVisible && isLayersSidebarVisible
 
   const { vigilanceAreas } = useGetFilteredVigilanceAreasQuery()
 

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
@@ -28,9 +28,9 @@ export function FilterTags() {
   }
 
   const hasFilters =
-    createdBy.length > 0 ||
-    seaFronts.length > 0 ||
-    filteredRegulatoryThemes.length > 0 ||
+    createdBy?.length > 0 ||
+    seaFronts?.length > 0 ||
+    filteredRegulatoryThemes?.length > 0 ||
     filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
 
   if (!hasFilters) {
@@ -39,17 +39,17 @@ export function FilterTags() {
 
   return (
     <StyledContainer data-cy="vigilance-areas-filter-tags">
-      {createdBy.map(author => (
+      {createdBy?.map(author => (
         <SingleTag key={author} onDelete={() => onDeleteTag(author, 'createdBy', createdBy)}>
           {author}
         </SingleTag>
       ))}
-      {seaFronts.map(seaFront => (
+      {seaFronts?.map(seaFront => (
         <SingleTag key={seaFront} onDelete={() => onDeleteTag(seaFront, 'seaFronts', seaFronts)}>
           {String(`Façade ${seaFront}`)}
         </SingleTag>
       ))}
-      {filteredRegulatoryThemes.map(theme => (
+      {filteredRegulatoryThemes?.map(theme => (
         <SingleTag key={theme} onDelete={() => deleteRegulatoryTheme(theme)}>
           {theme}
         </SingleTag>

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
@@ -1,0 +1,67 @@
+import { setFilteredRegulatoryThemes } from '@features/layersSelector/search/slice'
+import { VigilanceArea } from '@features/VigilanceArea/types'
+import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { SingleTag } from '@mtes-mct/monitor-ui'
+import styled from 'styled-components'
+
+import { vigilanceAreaFiltersActions } from './slice'
+
+export function FilterTags() {
+  const dispatch = useAppDispatch()
+  const { createdBy, seaFronts } = useAppSelector(state => state.vigilanceAreaFilters)
+  const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
+  const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
+
+  const onDeleteTag = (valueToDelete: string | any, filterKey: string, reportingFilter) => {
+    const updatedFilter = reportingFilter.filter(unit => unit !== valueToDelete)
+    dispatch(
+      vigilanceAreaFiltersActions.updateFilters({
+        key: filterKey,
+        value: updatedFilter.length === 0 ? undefined : updatedFilter
+      })
+    )
+  }
+
+  const deleteRegulatoryTheme = (regulatoryThemeToDelete: string) => {
+    dispatch(setFilteredRegulatoryThemes(filteredRegulatoryThemes.filter(theme => theme !== regulatoryThemeToDelete)))
+  }
+
+  const hasFilters =
+    createdBy.length > 0 ||
+    seaFronts.length > 0 ||
+    filteredRegulatoryThemes.length > 0 ||
+    filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
+
+  if (!hasFilters) {
+    return null
+  }
+
+  return (
+    <StyledContainer>
+      {createdBy.map(author => (
+        <SingleTag key={author} onDelete={() => onDeleteTag(author, 'createdBy', createdBy)}>
+          {author}
+        </SingleTag>
+      ))}
+      {seaFronts.map(seaFront => (
+        <SingleTag key={seaFront} onDelete={() => onDeleteTag(seaFront, 'seaFronts', seaFronts)}>
+          {String(`Façade ${seaFront}`)}
+        </SingleTag>
+      ))}
+      {filteredRegulatoryThemes.map(theme => (
+        <SingleTag key={theme} onDelete={() => deleteRegulatoryTheme(theme)}>
+          {theme}
+        </SingleTag>
+      ))}
+    </StyledContainer>
+  )
+}
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  margin-bottom: 2px;
+  flex-wrap: wrap;
+`

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
@@ -18,7 +18,7 @@ export function FilterTags() {
     dispatch(
       vigilanceAreaFiltersActions.updateFilters({
         key: filterKey,
-        value: updatedFilter.length === 0 ? undefined : updatedFilter
+        value: updatedFilter.length === 0 ? [] : updatedFilter
       })
     )
   }
@@ -38,7 +38,7 @@ export function FilterTags() {
   }
 
   return (
-    <StyledContainer>
+    <StyledContainer data-cy="vigilance-areas-filter-tags">
       {createdBy.map(author => (
         <SingleTag key={author} onDelete={() => onDeleteTag(author, 'createdBy', createdBy)}>
           {author}

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/FiltersTag.tsx
@@ -1,5 +1,4 @@
 import { setFilteredRegulatoryThemes } from '@features/layersSelector/search/slice'
-import { VigilanceArea } from '@features/VigilanceArea/types'
 import { useAppDispatch } from '@hooks/useAppDispatch'
 import { useAppSelector } from '@hooks/useAppSelector'
 import { SingleTag } from '@mtes-mct/monitor-ui'
@@ -11,7 +10,6 @@ export function FilterTags() {
   const dispatch = useAppDispatch()
   const { createdBy, seaFronts } = useAppSelector(state => state.vigilanceAreaFilters)
   const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
-  const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
 
   const onDeleteTag = (valueToDelete: string | any, filterKey: string, reportingFilter) => {
     const updatedFilter = reportingFilter.filter(unit => unit !== valueToDelete)
@@ -27,11 +25,7 @@ export function FilterTags() {
     dispatch(setFilteredRegulatoryThemes(filteredRegulatoryThemes.filter(theme => theme !== regulatoryThemeToDelete)))
   }
 
-  const hasFilters =
-    createdBy?.length > 0 ||
-    seaFronts?.length > 0 ||
-    filteredRegulatoryThemes?.length > 0 ||
-    filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
+  const hasFilters = createdBy?.length > 0 || seaFronts?.length > 0 || filteredRegulatoryThemes?.length > 0
 
   if (!hasFilters) {
     return null

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/SearchFilter.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/SearchFilter.tsx
@@ -1,0 +1,53 @@
+import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { TextInput, usePrevious } from '@mtes-mct/monitor-ui'
+import { debounce } from 'lodash'
+import { useCallback, useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+import { vigilanceAreaFiltersActions } from './slice'
+
+export function SearchFilter() {
+  const dispatch = useAppDispatch()
+  const searchQueryFilter = useAppSelector(state => state.vigilanceAreaFilters.searchQuery)
+  const previousSearchQueryFilter = usePrevious(searchQueryFilter)
+  const [searchText, setSearchText] = useState(searchQueryFilter)
+
+  const onQuery = useCallback(
+    (value: string | undefined) => {
+      dispatch(vigilanceAreaFiltersActions.setSearchQueryFilter(value))
+    },
+    [dispatch]
+  )
+
+  // when filters are reinitialzed, reset search text
+  useEffect(() => {
+    if (previousSearchQueryFilter && !searchQueryFilter) {
+      setSearchText(undefined)
+    }
+  }, [searchQueryFilter, previousSearchQueryFilter])
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedHandleChange = useCallback(debounce(onQuery, 500), [])
+
+  return (
+    <StyledSearch
+      isLabelHidden
+      isLight
+      isSearchInput
+      label="Rechercher dans les zones de vigilance"
+      name="vigilance-area-search"
+      onChange={value => {
+        setSearchText(value)
+        debouncedHandleChange(value)
+      }}
+      placeholder="Rechercher dans les zones de vigilance"
+      value={searchText}
+    />
+  )
+}
+
+const StyledSearch = styled(TextInput)`
+  border: 1px solid ${p => p.theme.color.lightGray};
+  width: 320px;
+`

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
@@ -1,7 +1,11 @@
 import { RegulatoryThemesFilter } from '@components/RegulatoryThemesFilter'
 import { CustomPeriodContainer, CustomPeriodLabel, TagsContainer } from '@components/style'
 import { ReinitializeFiltersButton } from '@features/commonComponents/ReinitializeFiltersButton'
-import { setFilteredRegulatoryThemes, setFilteredVigilanceAreaPeriod } from '@features/layersSelector/search/slice'
+import {
+  setFilteredRegulatoryThemes,
+  setFilteredVigilanceAreaPeriod,
+  setVigilanceAreaSpecificPeriodFilter
+} from '@features/layersSelector/search/slice'
 import { VigilanceArea } from '@features/VigilanceArea/types'
 import { useAppDispatch } from '@hooks/useAppDispatch'
 import { useAppSelector } from '@hooks/useAppSelector'
@@ -25,11 +29,15 @@ export function VigilanceAreasFilters() {
   const dispatch = useAppDispatch()
 
   const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
+  const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
 
-  const seaFrontFilter = useAppSelector(state => state.vigilanceAreaFilters.seaFronts)
-  const createdByFilter = useAppSelector(state => state.vigilanceAreaFilters.createdBy)
-  const statusFilter = useAppSelector(state => state.vigilanceAreaFilters.status)
-  const searchQueryFilter = useAppSelector(state => state.vigilanceAreaFilters.searchQuery)
+  const {
+    createdBy: createdByFilter,
+    seaFronts: seaFrontFilter,
+    searchQuery: searchQueryFilter,
+    status: statusFilter
+  } = useAppSelector(state => state.vigilanceAreaFilters)
+
   const seaFrontsAsOptions = Object.values(seaFrontLabels)
 
   const hasFilters =
@@ -37,7 +45,8 @@ export function VigilanceAreasFilters() {
     createdByFilter.length > 0 ||
     statusFilter.length !== 2 ||
     !!searchQueryFilter ||
-    filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
+    filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS ||
+    filteredRegulatoryThemes.length > 0
 
   const updateSeaFrontFilter = selectedSeaFronts => {
     dispatch(vigilanceAreaFiltersActions.setSeaFronts(selectedSeaFronts))
@@ -62,6 +71,7 @@ export function VigilanceAreasFilters() {
     dispatch(vigilanceAreaFiltersActions.resetFilters())
     dispatch(setFilteredRegulatoryThemes([]))
     dispatch(setFilteredVigilanceAreaPeriod(VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS))
+    dispatch(setVigilanceAreaSpecificPeriodFilter(undefined))
   }
 
   const hasCustomPeriodFilter = filteredVigilanceAreaPeriod === VigilanceArea.VigilanceAreaFilterPeriod.SPECIFIC_PERIOD
@@ -116,18 +126,20 @@ export function VigilanceAreasFilters() {
           />
         </>
       </FilterContainer>
-      <TagsContainer $withTopMargin={hasCustomPeriodFilter || hasFilters}>
-        {hasCustomPeriodFilter && (
-          <CustomPeriodContainer>
-            <CustomPeriodLabel>Période spécifique</CustomPeriodLabel>
-            <SpecificPeriodFilter />
-          </CustomPeriodContainer>
-        )}
+      {(hasCustomPeriodFilter || hasFilters) && (
+        <TagsContainer $withTopMargin={false}>
+          {hasCustomPeriodFilter && (
+            <CustomPeriodContainer>
+              <CustomPeriodLabel>Période spécifique</CustomPeriodLabel>
+              <SpecificPeriodFilter />
+            </CustomPeriodContainer>
+          )}
 
-        <FilterTags />
+          <FilterTags />
 
-        {(hasFilters || hasCustomPeriodFilter) && <ReinitializeFiltersButton onClick={resetFilters} />}
-      </TagsContainer>
+          {(hasFilters || hasCustomPeriodFilter) && <ReinitializeFiltersButton onClick={resetFilters} />}
+        </TagsContainer>
+      )}
     </Wrapper>
   )
 }
@@ -135,7 +147,7 @@ export function VigilanceAreasFilters() {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 16px;
 `
 
 const FilterContainer = styled.div`

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
@@ -1,3 +1,4 @@
+import { useGetTrigramsQuery } from '@api/vigilanceAreasAPI'
 import { RegulatoryThemesFilter } from '@components/RegulatoryThemesFilter'
 import { CustomPeriodContainer, CustomPeriodLabel, TagsContainer } from '@components/style'
 import { ReinitializeFiltersButton } from '@features/commonComponents/ReinitializeFiltersButton'
@@ -19,14 +20,11 @@ import { vigilanceAreaFiltersActions } from './slice'
 import { PeriodFilter } from '../../PeriodFilter'
 import { SpecificPeriodFilter } from '../../SpecificPeriodFilter'
 
-const CREATED_BY_OPTIONS = [
-  { label: 'ABC', value: 'ABC' },
-  { label: 'DEF', value: 'DEF' },
-  { label: 'GHI', value: 'GHI' },
-  { label: 'JKL', value: 'JKL' }
-]
 export function VigilanceAreasFilters() {
   const dispatch = useAppDispatch()
+
+  const { data: trigrams } = useGetTrigramsQuery()
+  const trigramsAsOptions = trigrams?.map(trigram => ({ label: trigram, value: trigram })) ?? []
 
   const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
   const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
@@ -90,7 +88,7 @@ export function VigilanceAreasFilters() {
           label="Zone créée par..."
           name="createdBy"
           onChange={updateCreatedByFilter}
-          options={CREATED_BY_OPTIONS}
+          options={trigramsAsOptions}
           placeholder="Zone créée par..."
           renderValue={() => createdByFilter && <OptionValue>{`Créée par (${createdByFilter.length})`}</OptionValue>}
           searchable

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
@@ -39,12 +39,12 @@ export function VigilanceAreasFilters() {
   const seaFrontsAsOptions = Object.values(seaFrontLabels)
 
   const hasFilters =
-    seaFrontFilter.length > 0 ||
-    createdByFilter.length > 0 ||
+    seaFrontFilter?.length > 0 ||
+    createdByFilter?.length > 0 ||
     statusFilter.length !== 2 ||
     !!searchQueryFilter ||
     filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS ||
-    filteredRegulatoryThemes.length > 0
+    filteredRegulatoryThemes?.length > 0
 
   const updateSeaFrontFilter = selectedSeaFronts => {
     dispatch(vigilanceAreaFiltersActions.setSeaFronts(selectedSeaFronts))

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/index.tsx
@@ -1,0 +1,151 @@
+import { RegulatoryThemesFilter } from '@components/RegulatoryThemesFilter'
+import { CustomPeriodContainer, CustomPeriodLabel, TagsContainer } from '@components/style'
+import { ReinitializeFiltersButton } from '@features/commonComponents/ReinitializeFiltersButton'
+import { setFilteredRegulatoryThemes, setFilteredVigilanceAreaPeriod } from '@features/layersSelector/search/slice'
+import { VigilanceArea } from '@features/VigilanceArea/types'
+import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { Checkbox, CheckPicker } from '@mtes-mct/monitor-ui'
+import { seaFrontLabels } from 'domain/entities/seaFrontType'
+import styled from 'styled-components'
+
+import { FilterTags } from './FiltersTag'
+import { SearchFilter } from './SearchFilter'
+import { vigilanceAreaFiltersActions } from './slice'
+import { PeriodFilter } from '../../PeriodFilter'
+import { SpecificPeriodFilter } from '../../SpecificPeriodFilter'
+
+const CREATED_BY_OPTIONS = [
+  { label: 'ABC', value: 'ABC' },
+  { label: 'DEF', value: 'DEF' },
+  { label: 'GHI', value: 'GHI' },
+  { label: 'JKL', value: 'JKL' }
+]
+export function VigilanceAreasFilters() {
+  const dispatch = useAppDispatch()
+
+  const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
+
+  const seaFrontFilter = useAppSelector(state => state.vigilanceAreaFilters.seaFronts)
+  const createdByFilter = useAppSelector(state => state.vigilanceAreaFilters.createdBy)
+  const statusFilter = useAppSelector(state => state.vigilanceAreaFilters.status)
+  const searchQueryFilter = useAppSelector(state => state.vigilanceAreaFilters.searchQuery)
+  const seaFrontsAsOptions = Object.values(seaFrontLabels)
+
+  const hasFilters =
+    seaFrontFilter.length > 0 ||
+    createdByFilter.length > 0 ||
+    statusFilter.length !== 2 ||
+    !!searchQueryFilter ||
+    filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
+
+  const updateSeaFrontFilter = selectedSeaFronts => {
+    dispatch(vigilanceAreaFiltersActions.setSeaFronts(selectedSeaFronts))
+  }
+
+  const updateCreatedByFilter = selectedCreatedBy => {
+    dispatch(vigilanceAreaFiltersActions.setCreatedBy(selectedCreatedBy))
+  }
+
+  const updateStatusFilter = (checked, status) => {
+    const filter = [...statusFilter]
+
+    if (checked) {
+      filter.push(status)
+    } else {
+      filter.splice(filter.indexOf(status), 1)
+    }
+
+    dispatch(vigilanceAreaFiltersActions.setStatus(filter))
+  }
+  const resetFilters = () => {
+    dispatch(vigilanceAreaFiltersActions.resetFilters())
+    dispatch(setFilteredRegulatoryThemes([]))
+    dispatch(setFilteredVigilanceAreaPeriod(VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS))
+  }
+
+  const hasCustomPeriodFilter = filteredVigilanceAreaPeriod === VigilanceArea.VigilanceAreaFilterPeriod.SPECIFIC_PERIOD
+
+  return (
+    <Wrapper>
+      <SearchFilter />
+
+      <FilterContainer>
+        <PeriodFilter style={{ width: 320 }} />
+        <RegulatoryThemesFilter style={{ width: 320 }} />
+
+        <CheckPicker
+          isLabelHidden
+          isTransparent
+          label="Zone créée par..."
+          name="createdBy"
+          onChange={updateCreatedByFilter}
+          options={CREATED_BY_OPTIONS}
+          placeholder="Zone créée par..."
+          renderValue={() => createdByFilter && <OptionValue>{`Créée par (${createdByFilter.length})`}</OptionValue>}
+          searchable
+          style={{ width: 181 }}
+          value={createdByFilter}
+        />
+        <CheckPicker
+          isLabelHidden
+          isTransparent
+          label="Façade"
+          name="seaFront"
+          onChange={updateSeaFrontFilter}
+          options={seaFrontsAsOptions ?? []}
+          placeholder="Façade"
+          renderValue={() => seaFrontFilter && <OptionValue>{`Façade (${seaFrontFilter.length})`}</OptionValue>}
+          style={{ width: 181 }}
+          value={seaFrontFilter}
+        />
+        <>
+          <Checkbox
+            key={VigilanceArea.StatusLabel.PUBLISHED}
+            checked={statusFilter.includes(VigilanceArea.Status.PUBLISHED)}
+            label={VigilanceArea.StatusLabel.PUBLISHED}
+            name={VigilanceArea.StatusLabel.PUBLISHED}
+            onChange={checked => updateStatusFilter(checked, VigilanceArea.Status.PUBLISHED)}
+          />
+          <Checkbox
+            key={VigilanceArea.StatusLabel.DRAFT}
+            checked={statusFilter.includes(VigilanceArea.Status.DRAFT)}
+            label={VigilanceArea.StatusLabel.DRAFT}
+            name={VigilanceArea.StatusLabel.DRAFT}
+            onChange={checked => updateStatusFilter(checked, VigilanceArea.Status.DRAFT)}
+          />
+        </>
+      </FilterContainer>
+      <TagsContainer $withTopMargin={hasCustomPeriodFilter || hasFilters}>
+        {hasCustomPeriodFilter && (
+          <CustomPeriodContainer>
+            <CustomPeriodLabel>Période spécifique</CustomPeriodLabel>
+            <SpecificPeriodFilter />
+          </CustomPeriodContainer>
+        )}
+
+        <FilterTags />
+
+        {(hasFilters || hasCustomPeriodFilter) && <ReinitializeFiltersButton onClick={resetFilters} />}
+      </TagsContainer>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
+const FilterContainer = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 16px;
+`
+const OptionValue = styled.span`
+  display: flex;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/slice.ts
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Filters/slice.ts
@@ -1,0 +1,47 @@
+import { VigilanceArea } from '@features/VigilanceArea/types'
+import { createSlice } from '@reduxjs/toolkit'
+import { persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
+
+const persistConfig = {
+  key: 'vigilanceAreaFilters',
+  storage
+}
+
+type VigilanceAreaSliceState = {
+  createdBy: string[]
+  seaFronts: string[]
+  searchQuery: string | undefined
+  status: VigilanceArea.Status[]
+}
+const INITIAL_STATE: VigilanceAreaSliceState = {
+  createdBy: [],
+  seaFronts: [],
+  searchQuery: undefined,
+  status: [VigilanceArea.Status.DRAFT, VigilanceArea.Status.PUBLISHED]
+}
+export const vigilanceAreaFiltersSlice = createSlice({
+  initialState: INITIAL_STATE,
+  name: 'vigilanceAreaFilters',
+  reducers: {
+    resetFilters: () => INITIAL_STATE,
+    setCreatedBy: (state, action) => {
+      state.createdBy = action.payload
+    },
+    setSeaFronts: (state, action) => {
+      state.seaFronts = action.payload
+    },
+    setSearchQueryFilter: (state, action) => {
+      state.searchQuery = action.payload
+    },
+    setStatus: (state, action) => {
+      state.status = action.payload
+    },
+    updateFilters: (state, action) => {
+      state[action.payload.key] = action.payload.value
+    }
+  }
+})
+
+export const vigilanceAreaFiltersActions = vigilanceAreaFiltersSlice.actions
+export const vigilanceAreaFiltersPersistedReducer = persistReducer(persistConfig, vigilanceAreaFiltersSlice.reducer)

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Rows/HighlightCell.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Rows/HighlightCell.tsx
@@ -1,13 +1,14 @@
+import { useAppSelector } from '@hooks/useAppSelector'
 import Highlighter from 'react-highlight-words'
 
 export function HighlightCell({ text }) {
-  // TODO(30/10/24): get search query filters to add to `searchWords` when filters are added
+  const searchQuery = useAppSelector(state => state.vigilanceAreaFilters.searchQuery)
 
   return (
     <Highlighter
       autoEscape
       highlightClassName="highlight"
-      searchWords={[]}
+      searchWords={searchQuery && searchQuery.length > 0 ? searchQuery.split(' ') : []}
       textToHighlight={text ?? '-'}
       title={text}
     />

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/index.tsx
@@ -2,6 +2,7 @@ import { useGetVigilanceAreasQuery } from '@api/vigilanceAreasAPI'
 import { SideWindowContent } from '@features/SideWindow/style'
 import styled from 'styled-components'
 
+import { VigilanceAreasFilters } from './Filters'
 import { VigilanceAreasTable } from './VigilanceAreasTable'
 
 export function VigilancesAreasList() {
@@ -12,6 +13,7 @@ export function VigilancesAreasList() {
       <StyledHeader>
         <Title data-cy="SideWindowHeader-title">Zones de vigilance</Title>
       </StyledHeader>
+      <VigilanceAreasFilters />
       {isError ? (
         <p data-cy="listReportingWrapper">Erreur au chargement des données</p>
       ) : (

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/index.tsx
@@ -1,12 +1,12 @@
-import { useGetVigilanceAreasQuery } from '@api/vigilanceAreasAPI'
 import { SideWindowContent } from '@features/SideWindow/style'
+import { useGetFilteredVigilanceAreasQuery } from '@features/VigilanceArea/hooks/useGetFilteredVigilanceAreasQuery'
 import styled from 'styled-components'
 
 import { VigilanceAreasFilters } from './Filters'
 import { VigilanceAreasTable } from './VigilanceAreasTable'
 
 export function VigilancesAreasList() {
-  const { data, isError, isFetching, isLoading } = useGetVigilanceAreasQuery()
+  const { isError, isFetching, isLoading, vigilanceAreas } = useGetFilteredVigilanceAreasQuery()
 
   return (
     <SideWindowContent>
@@ -17,7 +17,10 @@ export function VigilancesAreasList() {
       {isError ? (
         <p data-cy="listReportingWrapper">Erreur au chargement des données</p>
       ) : (
-        <VigilanceAreasTable isLoading={isLoading || isFetching} vigilanceAreas={Object.values(data?.entities ?? {})} />
+        <VigilanceAreasTable
+          isLoading={isLoading || isFetching}
+          vigilanceAreas={Object.values(vigilanceAreas?.entities ?? {})}
+        />
       )}
     </SideWindowContent>
   )

--- a/frontend/src/features/VigilanceArea/hooks/useGetFilteredVigilanceAreasQuery.ts
+++ b/frontend/src/features/VigilanceArea/hooks/useGetFilteredVigilanceAreasQuery.ts
@@ -1,0 +1,84 @@
+import { useGetVigilanceAreasQuery } from '@api/vigilanceAreasAPI'
+import { getFilterVigilanceAreasPerPeriod } from '@features/layersSelector/utils/getFilteredVigilanceAreasPerPeriod'
+import { useAppSelector } from '@hooks/useAppSelector'
+import { CustomSearch } from '@mtes-mct/monitor-ui'
+import { useMemo } from 'react'
+
+import { TWO_MINUTES } from '../../../constants'
+import { isVigilanceAreaPartOfCreatedBy } from '../useCases/filters/isVigilanceAreaPartOfCreatedBy'
+import { isVigilanceAreaPartOfSeaFront } from '../useCases/filters/isVigilanceAreaPartOfSeaFront'
+import { isVigilanceAreaPartOfStatus } from '../useCases/filters/isVigilanceAreaPartOfStatus'
+import { isVigilanceAreaPartOfTheme } from '../useCases/filters/isVigilanceAreaPartOfTheme'
+
+import type { VigilanceArea } from '../types'
+
+export const useGetFilteredVigilanceAreasQuery = () => {
+  const { createdBy, seaFronts, searchQuery, status } = useAppSelector(state => state.vigilanceAreaFilters)
+  const filteredVigilanceAreaPeriod = useAppSelector(state => state.layerSearch.filteredVigilanceAreaPeriod)
+  const vigilanceAreaSpecificPeriodFilter = useAppSelector(state => state.layerSearch.vigilanceAreaSpecificPeriodFilter)
+  const filteredRegulatoryThemes = useAppSelector(state => state.layerSearch.filteredRegulatoryThemes)
+
+  const { data, isError, isFetching, isLoading } = useGetVigilanceAreasQuery(undefined, {
+    pollingInterval: TWO_MINUTES
+  })
+
+  const filteredVigilanceAreas = useMemo(() => {
+    if (!data?.entities) {
+      return { entities: {}, ids: [] }
+    }
+
+    const vigilanceAreas = Object.values(data.entities)
+
+    const tempVigilanceAreas = vigilanceAreas.filter(
+      vigilanceArea =>
+        isVigilanceAreaPartOfCreatedBy(vigilanceArea, createdBy) &&
+        isVigilanceAreaPartOfSeaFront(vigilanceArea, seaFronts) &&
+        isVigilanceAreaPartOfStatus(vigilanceArea, status) &&
+        isVigilanceAreaPartOfTheme(vigilanceArea, filteredRegulatoryThemes)
+    )
+
+    const vigilanceAreasByPeriod = getFilterVigilanceAreasPerPeriod(
+      tempVigilanceAreas,
+      filteredVigilanceAreaPeriod,
+      vigilanceAreaSpecificPeriodFilter
+    )
+
+    const customSearch = new CustomSearch(
+      vigilanceAreasByPeriod,
+      [
+        { name: 'comments', weight: 0.1 },
+        { name: 'name', weight: 0.9 }
+      ],
+      {
+        cacheKey: 'VIGILANCE_AREAS_LIST_SEARCH',
+        isStrict: true,
+        withCacheInvalidation: true
+      }
+    )
+
+    let vigilanceAreasBySearchQuery = vigilanceAreasByPeriod
+    if (searchQuery && searchQuery.trim().length > 0) {
+      vigilanceAreasBySearchQuery = customSearch.find(searchQuery)
+    }
+
+    return {
+      entities: vigilanceAreasBySearchQuery.reduce((acc, vigilanceArea) => {
+        acc[vigilanceArea.id] = vigilanceArea
+
+        return acc
+      }, {} as Record<string, VigilanceArea.VigilanceArea>),
+      ids: vigilanceAreasBySearchQuery.map(vigilanceArea => vigilanceArea.id)
+    }
+  }, [
+    data?.entities,
+    filteredVigilanceAreaPeriod,
+    vigilanceAreaSpecificPeriodFilter,
+    searchQuery,
+    createdBy,
+    seaFronts,
+    status,
+    filteredRegulatoryThemes
+  ])
+
+  return { isError, isFetching, isLoading, vigilanceAreas: filteredVigilanceAreas }
+}

--- a/frontend/src/features/VigilanceArea/types.ts
+++ b/frontend/src/features/VigilanceArea/types.ts
@@ -20,6 +20,7 @@ export namespace VigilanceArea {
     linkedRegulatoryAreas: Array<number>
     links: Array<Link>
     name: string | undefined
+    seaFront: string | undefined
     source: string | undefined
     startDatePeriod: string | undefined
     themes: Array<string>

--- a/frontend/src/features/VigilanceArea/types.ts
+++ b/frontend/src/features/VigilanceArea/types.ts
@@ -82,6 +82,13 @@ export namespace VigilanceArea {
     SPECIFIC_PERIOD = 'Période spécifique'
   }
 
+  export type VigilanceAreaFilterPeriodType =
+    | 'AT_THE_MOMENT'
+    | 'NEXT_THREE_MONTHS'
+    | 'CURRENT_QUARTER'
+    | 'CURRENT_YEAR'
+    | 'SPECIFIC_PERIOD'
+
   export type VigilanceAreaProperties = Omit<VigilanceArea.VigilanceArea, 'geom'> & {
     id: number
     isSelected: boolean
@@ -109,5 +116,17 @@ export namespace VigilanceArea {
   export enum Orientation {
     LANDSCAPE = 'landscape',
     PORTRAIT = 'portrait'
+  }
+
+  export type StatusType = 'DRAFT' | 'PUBLISHED'
+
+  export enum Status {
+    DRAFT = 'DRAFT',
+    PUBLISHED = 'PUBLISHED'
+  }
+
+  export enum StatusLabel {
+    DRAFT = 'Non publiée',
+    PUBLISHED = 'Publiée'
   }
 }

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfCreatedBy.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfCreatedBy.ts
@@ -1,0 +1,12 @@
+import type { VigilanceArea } from '@features/VigilanceArea/types'
+
+export function isVigilanceAreaPartOfCreatedBy(
+  vigilanceArea: VigilanceArea.VigilanceArea,
+  createdBy: string[]
+): boolean {
+  if (createdBy.length === 0) {
+    return true
+  }
+
+  return !!createdBy.includes(vigilanceArea.createdBy ?? '')
+}

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfCreatedBy.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfCreatedBy.ts
@@ -8,5 +8,5 @@ export function isVigilanceAreaPartOfCreatedBy(
     return true
   }
 
-  return !!createdBy.includes(vigilanceArea.createdBy ?? '')
+  return createdBy.includes(vigilanceArea.createdBy ?? '')
 }

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfCreatedBy.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfCreatedBy.ts
@@ -2,9 +2,9 @@ import type { VigilanceArea } from '@features/VigilanceArea/types'
 
 export function isVigilanceAreaPartOfCreatedBy(
   vigilanceArea: VigilanceArea.VigilanceArea,
-  createdBy: string[]
+  createdBy: string[] | undefined
 ): boolean {
-  if (createdBy.length === 0) {
+  if (!createdBy || createdBy.length === 0) {
     return true
   }
 

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfSeaFront.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfSeaFront.ts
@@ -1,0 +1,9 @@
+import type { VigilanceArea } from '@features/VigilanceArea/types'
+
+export function isVigilanceAreaPartOfSeaFront(vigilanceArea: VigilanceArea.VigilanceArea, seaFront: string[]): boolean {
+  if (seaFront.length === 0) {
+    return true
+  }
+
+  return !!seaFront.includes(vigilanceArea.seaFront ?? '')
+}

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfSeaFront.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfSeaFront.ts
@@ -1,7 +1,10 @@
 import type { VigilanceArea } from '@features/VigilanceArea/types'
 
-export function isVigilanceAreaPartOfSeaFront(vigilanceArea: VigilanceArea.VigilanceArea, seaFront: string[]): boolean {
-  if (seaFront.length === 0) {
+export function isVigilanceAreaPartOfSeaFront(
+  vigilanceArea: VigilanceArea.VigilanceArea,
+  seaFront: string[] | undefined
+): boolean {
+  if (!seaFront || seaFront.length === 0) {
     return true
   }
 

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfSeaFront.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfSeaFront.ts
@@ -8,5 +8,5 @@ export function isVigilanceAreaPartOfSeaFront(
     return true
   }
 
-  return !!seaFront.includes(vigilanceArea.seaFront ?? '')
+  return seaFront.includes(vigilanceArea.seaFront ?? '')
 }

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfStatus.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfStatus.ts
@@ -1,0 +1,19 @@
+import { VigilanceArea } from '@features/VigilanceArea/types'
+
+export function isVigilanceAreaPartOfStatus(
+  vigilanceArea: VigilanceArea.VigilanceArea,
+  status: VigilanceArea.Status[]
+): boolean {
+  if (status.length === 0) {
+    return true
+  }
+
+  if (vigilanceArea.isDraft && status.includes(VigilanceArea.Status.DRAFT)) {
+    return true
+  }
+  if (!vigilanceArea.isDraft && status.includes(VigilanceArea.Status.PUBLISHED)) {
+    return true
+  }
+
+  return false
+}

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfStatus.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfStatus.ts
@@ -8,12 +8,8 @@ export function isVigilanceAreaPartOfStatus(
     return true
   }
 
-  if (vigilanceArea.isDraft && status.includes(VigilanceArea.Status.DRAFT)) {
-    return true
-  }
-  if (!vigilanceArea.isDraft && status.includes(VigilanceArea.Status.PUBLISHED)) {
-    return true
-  }
-
-  return false
+  return (
+    (vigilanceArea.isDraft && status.includes(VigilanceArea.Status.DRAFT)) ||
+    (!vigilanceArea.isDraft && status.includes(VigilanceArea.Status.PUBLISHED))
+  )
 }

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfTheme.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfTheme.ts
@@ -1,0 +1,12 @@
+import type { VigilanceArea } from '@features/VigilanceArea/types'
+
+export function isVigilanceAreaPartOfTheme(
+  vigilanceArea: VigilanceArea.VigilanceArea,
+  themes: string[] | undefined
+): boolean {
+  if (!themes || themes.length === 0) {
+    return true
+  }
+
+  return !!vigilanceArea.themes?.find(theme => themes.includes(theme))
+}

--- a/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfTheme.ts
+++ b/frontend/src/features/VigilanceArea/useCases/filters/isVigilanceAreaPartOfTheme.ts
@@ -8,5 +8,5 @@ export function isVigilanceAreaPartOfTheme(
     return true
   }
 
-  return !!vigilanceArea.themes?.find(theme => themes.includes(theme))
+  return vigilanceArea.themes?.some(theme => themes.includes(theme))
 }

--- a/frontend/src/features/layersSelector/index.tsx
+++ b/frontend/src/features/layersSelector/index.tsx
@@ -5,6 +5,7 @@ import {
   getIsLinkingZonesToVigilanceArea
 } from '@features/VigilanceArea/slice'
 import { IconButton, Accent, Size, Icon, THEME } from '@mtes-mct/monitor-ui'
+import { layerSidebarActions } from 'domain/shared_slices/LayerSidebar'
 import { FulfillingBouncingCircleSpinner } from 'react-epic-spinners'
 import styled from 'styled-components'
 
@@ -51,6 +52,7 @@ export function LayersSidebar({ isSuperUser }: { isSuperUser: boolean }) {
       dispatch(closeMetadataPanel())
     }
     dispatch(setDisplayedItems({ isLayersSidebarVisible: !isLayersSidebarVisible }))
+    dispatch(layerSidebarActions.toggleRegFilters(true))
   }
 
   return (

--- a/frontend/src/features/layersSelector/search/LayerFilters.tsx
+++ b/frontend/src/features/layersSelector/search/LayerFilters.tsx
@@ -112,6 +112,7 @@ export function LayerFilters({
       {!isLinkingRegulatoryToVigilanceArea && (
         <SelectContainer>
           <StyledCheckPicker
+            key={String(ampTypes.length)}
             customSearch={AMPCustomSearch}
             isLabelHidden
             isTransparent

--- a/frontend/src/features/layersSelector/search/LayerFilters.tsx
+++ b/frontend/src/features/layersSelector/search/LayerFilters.tsx
@@ -6,6 +6,7 @@ import {
   getIsLinkingZonesToVigilanceArea
 } from '@features/VigilanceArea/slice'
 import { VigilanceArea } from '@features/VigilanceArea/types'
+import { useAppDispatch } from '@hooks/useAppDispatch'
 import { useAppSelector } from '@hooks/useAppSelector'
 import { useGetCurrentUserAuthorizationQueryOverride } from '@hooks/useGetCurrentUserAuthorizationQueryOverride'
 import {
@@ -21,6 +22,8 @@ import {
 } from '@mtes-mct/monitor-ui'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
+
+import { setIsAmpSearchResultsVisible, setIsRegulatorySearchResultsVisible } from './slice'
 
 type LayerFiltersProps = {
   ampTypes: Option<string>[]
@@ -48,6 +51,7 @@ export function LayerFilters({
   setFilteredRegulatoryThemes,
   updateDateRangeFilter
 }: LayerFiltersProps) {
+  const dispatch = useAppDispatch()
   const { data: user } = useGetCurrentUserAuthorizationQueryOverride()
   const isSuperUser = user?.isSuperUser
 
@@ -65,10 +69,16 @@ export function LayerFilters({
     setFilteredAmpTypes(nextAmpThemes ?? [])
   }
   const handleDeleteAmpType = (ampThemeToDelete: string) => () => {
+    if (filteredAmpTypes.length === 1) {
+      dispatch(setIsAmpSearchResultsVisible(false))
+    }
     setFilteredAmpTypes(filteredAmpTypes.filter(theme => theme !== ampThemeToDelete))
   }
 
   const handleDeleteRegulatoryTheme = (regulatoryThemeToDelete: string) => () => {
+    if (filteredRegulatoryThemes.length === 1) {
+      dispatch(setIsRegulatorySearchResultsVisible(false))
+    }
     setFilteredRegulatoryThemes(filteredRegulatoryThemes.filter(theme => theme !== regulatoryThemeToDelete))
   }
 

--- a/frontend/src/features/layersSelector/search/ResultsList/index.tsx
+++ b/frontend/src/features/layersSelector/search/ResultsList/index.tsx
@@ -1,5 +1,5 @@
-import { useGetVigilanceAreasQuery } from '@api/vigilanceAreasAPI'
 import { closeMetadataPanel } from '@features/layersSelector/metadataPanel/slice'
+import { useGetFilteredVigilanceAreasQuery } from '@features/VigilanceArea/hooks/useGetFilteredVigilanceAreasQuery'
 import {
   getIsLinkingAMPToVigilanceArea,
   getIsLinkingRegulatoryToVigilanceArea,
@@ -63,7 +63,7 @@ export function ResultList({ searchedText }: ResultListProps) {
   const ampResulstsByAMPName = groupBy(ampsSearchResult ?? amps?.ids, a => amps?.entities[a]?.name)
   const totalAmps = ampsSearchResult?.length ?? amps?.ids?.length ?? 0
 
-  const { data: vigilanceAreas } = useGetVigilanceAreasQuery()
+  const { vigilanceAreas } = useGetFilteredVigilanceAreasQuery()
   const vigilanceAreasIds = vigilanceAreaSearchResult ?? vigilanceAreas?.ids
   const totalVigilanceAreas = vigilanceAreaSearchResult?.length ?? vigilanceAreas?.ids.length ?? 0
 

--- a/frontend/src/features/layersSelector/search/SearchInput.tsx
+++ b/frontend/src/features/layersSelector/search/SearchInput.tsx
@@ -1,3 +1,4 @@
+import { VigilanceArea } from '@features/VigilanceArea/types'
 import { Accent, IconButton, Icon, Size, TextInput } from '@mtes-mct/monitor-ui'
 import styled from 'styled-components'
 
@@ -11,8 +12,11 @@ export function SearchInput({
   setGlobalSearchText,
   toggleRegFilters
 }) {
+  const defaulVigilanceAreaPeriod =
+    filteredVigilanceAreaPeriod === VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
+
   const numberOfFilters =
-    (filteredRegulatoryThemes?.length || 0) + (filteredAmpTypes?.length || 0) + (filteredVigilanceAreaPeriod ? 1 : 0)
+    (filteredRegulatoryThemes?.length || 0) + (filteredAmpTypes?.length || 0) + (!defaulVigilanceAreaPeriod ? 1 : 0)
 
   return (
     <SearchHeader>

--- a/frontend/src/features/layersSelector/search/SearchInput.tsx
+++ b/frontend/src/features/layersSelector/search/SearchInput.tsx
@@ -12,11 +12,11 @@ export function SearchInput({
   setGlobalSearchText,
   toggleRegFilters
 }) {
-  const defaulVigilanceAreaPeriod =
+  const defaultVigilanceAreaPeriod =
     filteredVigilanceAreaPeriod === VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
 
   const numberOfFilters =
-    (filteredRegulatoryThemes?.length || 0) + (filteredAmpTypes?.length || 0) + (!defaulVigilanceAreaPeriod ? 1 : 0)
+    (filteredRegulatoryThemes?.length || 0) + (filteredAmpTypes?.length || 0) + (!defaultVigilanceAreaPeriod ? 1 : 0)
 
   return (
     <SearchHeader>

--- a/frontend/src/features/layersSelector/search/hooks/useSearchLayers.ts
+++ b/frontend/src/features/layersSelector/search/hooks/useSearchLayers.ts
@@ -1,7 +1,11 @@
+import { useGetAMPsQuery } from '@api/ampsAPI'
+import { useGetRegulatoryLayersQuery } from '@api/regulatoryLayersAPI'
+import { useGetVigilanceAreasQuery } from '@api/vigilanceAreasAPI'
 import { closeMetadataPanel } from '@features/layersSelector/metadataPanel/slice'
 import { getIntersectingLayerIds } from '@features/layersSelector/utils/getIntersectingLayerIds'
 import { VigilanceArea } from '@features/VigilanceArea/types'
 import { useAppDispatch } from '@hooks/useAppDispatch'
+import { useGetCurrentUserAuthorizationQueryOverride } from '@hooks/useGetCurrentUserAuthorizationQueryOverride'
 import Fuse, { type Expression } from 'fuse.js'
 import { debounce } from 'lodash'
 import { useMemo } from 'react'
@@ -12,8 +16,15 @@ import { setAMPsSearchResult, setRegulatoryLayersSearchResult, setVigilanceAreas
 import type { AMP } from 'domain/entities/AMPs'
 import type { RegulatoryLayerCompact } from 'domain/entities/regulatory'
 
-export function useSearchLayers({ amps, regulatoryLayers, vigilanceAreaLayers }) {
+export function useSearchLayers() {
   const dispatch = useAppDispatch()
+  const { data: user } = useGetCurrentUserAuthorizationQueryOverride()
+  const isSuperUser = user?.isSuperUser
+
+  const { data: amps } = useGetAMPsQuery()
+  const { data: regulatoryLayers } = useGetRegulatoryLayersQuery()
+  const { data: vigilanceAreaLayers } = useGetVigilanceAreasQuery(undefined, { skip: !isSuperUser })
+
   const debouncedSearchLayers = useMemo(() => {
     const fuseRegulatory = new Fuse((regulatoryLayers?.entities && Object.values(regulatoryLayers?.entities)) || [], {
       ignoreLocation: true,

--- a/frontend/src/features/layersSelector/search/index.tsx
+++ b/frontend/src/features/layersSelector/search/index.tsx
@@ -1,3 +1,4 @@
+import { VigilanceArea } from '@features/VigilanceArea/types'
 import { type DateAsStringRange } from '@mtes-mct/monitor-ui'
 import { getAmpsAsOptions } from '@utils/getAmpsAsOptions'
 import { layerSidebarActions } from 'domain/shared_slices/LayerSidebar'
@@ -90,7 +91,7 @@ export function LayerSearch() {
       regulatoryThemes: [],
       searchedText: globalSearchText,
       shouldSearchByExtent: shouldFilterSearchOnMapExtent,
-      vigilanceAreaPeriodFilter: undefined,
+      vigilanceAreaPeriodFilter: VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS,
       vigilanceAreaSpecificPeriodFilter: undefined
     })
   }
@@ -115,7 +116,10 @@ export function LayerSearch() {
   const ampTypes = useMemo(() => getAmpsAsOptions(amps ?? []), [amps])
 
   const allowResetResults =
-    !_.isEmpty(regulatoryLayersSearchResult) || !_.isEmpty(ampsSearchResult) || !_.isEmpty(vigilanceAreaSearchResult)
+    !_.isEmpty(regulatoryLayersSearchResult) ||
+    !_.isEmpty(ampsSearchResult) ||
+    (!_.isEmpty(vigilanceAreaSearchResult) &&
+      filteredVigilanceAreaPeriod !== VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS)
 
   return (
     <SearchContainer>

--- a/frontend/src/features/layersSelector/search/slice.ts
+++ b/frontend/src/features/layersSelector/search/slice.ts
@@ -1,10 +1,13 @@
+import { VigilanceArea } from '@features/VigilanceArea/types'
 import { type PayloadAction, createSlice } from '@reduxjs/toolkit'
+
+import type { DateAsStringRange } from '@mtes-mct/monitor-ui'
 
 type LayerSearchState = {
   ampsSearchResult: number[] | undefined
   filteredAmpTypes: string[]
   filteredRegulatoryThemes: string[]
-  filteredVigilanceAreaPeriod: string | undefined
+  filteredVigilanceAreaPeriod: VigilanceArea.VigilanceAreaFilterPeriod | undefined
   globalSearchText: string
   isAmpSearchResultsVisible: boolean
   isRegulatorySearchResultsVisible: boolean
@@ -13,13 +16,13 @@ type LayerSearchState = {
   searchExtent: number[] | undefined
   shouldFilterSearchOnMapExtent: boolean
   vigilanceAreaSearchResult: number[] | undefined
-  vigilanceAreaSpecificPeriodFilter: string[] | undefined
+  vigilanceAreaSpecificPeriodFilter: DateAsStringRange | undefined
 }
 const initialState: LayerSearchState = {
   ampsSearchResult: undefined,
   filteredAmpTypes: [],
   filteredRegulatoryThemes: [],
-  filteredVigilanceAreaPeriod: undefined,
+  filteredVigilanceAreaPeriod: VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS,
   globalSearchText: '',
   isAmpSearchResultsVisible: false,
   isRegulatorySearchResultsVisible: false,
@@ -35,6 +38,15 @@ const layerSearchSlice = createSlice({
   initialState,
   name: 'layerSearch',
   reducers: {
+    resetFilters(state) {
+      state.filteredRegulatoryThemes = []
+      state.isRegulatorySearchResultsVisible = false
+      state.filteredAmpTypes = []
+      state.isAmpSearchResultsVisible = false
+      state.filteredVigilanceAreaPeriod = VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
+      state.vigilanceAreaSpecificPeriodFilter = undefined
+      state.isVigilanceAreaSearchResultsVisible = false
+    },
     resetSearch(state) {
       state.regulatoryLayersSearchResult = undefined
       state.isRegulatorySearchResultsVisible = false
@@ -45,7 +57,7 @@ const layerSearchSlice = createSlice({
       state.vigilanceAreaSearchResult = undefined
       state.isVigilanceAreaSearchResultsVisible = false
       state.vigilanceAreaSpecificPeriodFilter = undefined
-      state.filteredVigilanceAreaPeriod = undefined
+      state.filteredVigilanceAreaPeriod = VigilanceArea.VigilanceAreaFilterPeriod.NEXT_THREE_MONTHS
       state.shouldFilterSearchOnMapExtent = false
       state.globalSearchText = ''
       state.searchExtent = undefined
@@ -71,7 +83,7 @@ const layerSearchSlice = createSlice({
       state.filteredRegulatoryThemes = action.payload
     },
 
-    setFilteredVigilanceAreaPeriod(state, action: PayloadAction<string | undefined>) {
+    setFilteredVigilanceAreaPeriod(state, action: PayloadAction<VigilanceArea.VigilanceAreaFilterPeriod | undefined>) {
       state.filteredVigilanceAreaPeriod = action.payload
     },
 
@@ -102,7 +114,7 @@ const layerSearchSlice = createSlice({
       state.shouldFilterSearchOnMapExtent = action.payload
     },
 
-    setVigilanceAreaSpecificPeriodFilter(state, action: PayloadAction<Array<string> | undefined>) {
+    setVigilanceAreaSpecificPeriodFilter(state, action: PayloadAction<DateAsStringRange | undefined>) {
       state.vigilanceAreaSpecificPeriodFilter = action.payload
     },
     setVigilanceAreasSearchResult(state, action: PayloadAction<Array<number> | undefined>) {
@@ -112,6 +124,7 @@ const layerSearchSlice = createSlice({
 })
 
 export const {
+  resetFilters,
   resetSearch,
   resetSearchExtent,
   setAMPsSearchResult,

--- a/frontend/src/features/layersSelector/utils/getFilteredVigilanceAreasPerPeriod.ts
+++ b/frontend/src/features/layersSelector/utils/getFilteredVigilanceAreasPerPeriod.ts
@@ -59,15 +59,15 @@ export const getFilterVigilanceAreasPerPeriod = (vigilanceAreas, periodFilter, v
       return (
         isWithinPeriod(startDate, startDateFilter, endDateFilter) ||
         isWithinPeriod(endDate, startDateFilter, endDateFilter) ||
-        startDateFilter.isBetween(startDate, endDate) ||
-        endDateFilter.isBetween(startDate, endDate)
+        startDateFilter?.isBetween(startDate, endDate) ||
+        endDateFilter?.isBetween(startDate, endDate)
       )
     }
 
     if (
       !!startDateFilter &&
       !!endDateFilter &&
-      (startDateFilter.isBetween(startDate, endDate) || endDateFilter.isBetween(startDate, endDate))
+      (startDateFilter?.isBetween(startDate, endDate) || endDateFilter.isBetween(startDate, endDate))
     ) {
       return true
     }

--- a/frontend/src/features/missions/MissionsSearch.tsx
+++ b/frontend/src/features/missions/MissionsSearch.tsx
@@ -48,5 +48,6 @@ export function MissionSearch() {
 
 const StyledSearch = styled(TextInput)`
   border: 1px solid ${p => p.theme.color.lightGray};
+  margin-bottom: 8px;
   width: 410px;
 `

--- a/frontend/src/features/missions/components/Filters/Map/index.tsx
+++ b/frontend/src/features/missions/components/Filters/Map/index.tsx
@@ -1,5 +1,6 @@
 import { RTK_DEFAULT_QUERY_OPTIONS } from '@api/constants'
 import { useGetControlUnitsQuery } from '@api/controlUnitsAPI'
+import { CustomPeriodContainer } from '@components/style'
 import { useAppDispatch } from '@hooks/useAppDispatch'
 import { useAppSelector } from '@hooks/useAppSelector'
 import { useGetControlPlans } from '@hooks/useGetControlPlans'
@@ -123,6 +124,7 @@ export const MapMissionFilters = forwardRef<HTMLDivElement, MapMissionFiltersPro
                   startedAfter && startedBefore ? [new Date(startedAfter), new Date(startedBefore)] : undefined
                 }
                 hasSingleCalendar
+                isLabelHidden
                 isStringDate
                 label="Période spécifique"
                 name="missionDateRange"
@@ -302,10 +304,7 @@ export const StyledTagsContainer = styled.div<{ $withTopMargin: boolean }>`
   align-items: end;
 `
 
-const StyledCustomPeriodContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+const StyledCustomPeriodContainer = styled(CustomPeriodContainer)`
   margin-top: 5px;
 `
 

--- a/frontend/src/features/missions/components/Filters/Table/index.tsx
+++ b/frontend/src/features/missions/components/Filters/Table/index.tsx
@@ -236,7 +236,7 @@ const FilterWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
 `
 const FilterWrapperLine = styled.div`
   display: flex;

--- a/frontend/src/features/missions/components/Filters/Table/index.tsx
+++ b/frontend/src/features/missions/components/Filters/Table/index.tsx
@@ -1,3 +1,4 @@
+import { CustomPeriodContainer, TagsContainer } from '@components/style'
 import { ReinitializeFiltersButton } from '@features/commonComponents/ReinitializeFiltersButton'
 import { MissionSearch } from '@features/missions/MissionsSearch'
 import { useAppSelector } from '@hooks/useAppSelector'
@@ -205,7 +206,7 @@ export const TableMissionFilters = forwardRef<HTMLDivElement, TableMissionFilter
             />
           </FilterWrapperLine>
         </FilterWrapper>
-        <StyledTagsContainer $withTopMargin={selectedPeriod === DateRangeEnum.CUSTOM || hasFilters}>
+        <TagsContainer $withTopMargin={selectedPeriod === DateRangeEnum.CUSTOM || hasFilters}>
           {selectedPeriod === DateRangeEnum.CUSTOM && (
             <StyledCustomPeriodContainer>
               <DateRangePicker
@@ -225,7 +226,7 @@ export const TableMissionFilters = forwardRef<HTMLDivElement, TableMissionFilter
           <FilterTags />
 
           {hasFilters && <ReinitializeFiltersButton onClick={onResetFilters} />}
-        </StyledTagsContainer>
+        </TagsContainer>
       </>
     )
   }
@@ -253,20 +254,7 @@ const StyledSelect = styled(Select)`
   }
 `
 
-export const StyledTagsContainer = styled.div<{ $withTopMargin: boolean }>`
-  margin-top: ${p => (p.$withTopMargin ? '16px' : '0px')};
-  display: flex;
-  flex-direction: row;
-  max-width: 100%;
-  flex-wrap: wrap;
-  gap: 16px;
-  align-items: end;
-`
-
-const StyledCustomPeriodContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+const StyledCustomPeriodContainer = styled(CustomPeriodContainer)`
   margin-top: 5px;
 `
 

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -1,6 +1,7 @@
 import { dashboardFiltersPersistedReducer } from '@features/Dashboard/components/DashboardForm/slice'
 import { dashboardReducer } from '@features/Dashboard/slice'
 import { interestPointSlicePersistedReducer } from '@features/InterestPoint/slice'
+import { vigilanceAreaFiltersPersistedReducer } from '@features/VigilanceArea/components/VigilanceAreasList/Filters/slice'
 import { vigilanceAreaPersistedReducer } from '@features/VigilanceArea/slice'
 
 import { geoserverApi, monitorenvPrivateApi, monitorenvPublicApi } from '../api/api'
@@ -67,5 +68,6 @@ export const homeReducers = {
   sideWindow: sideWindowReducer,
   station: stationReducer,
   stationTable: stationTablePersistedReducer,
-  vigilanceArea: vigilanceAreaPersistedReducer
+  vigilanceArea: vigilanceAreaPersistedReducer,
+  vigilanceAreaFilters: vigilanceAreaFiltersPersistedReducer
 }


### PR DESCRIPTION
- Mise en place des filtres en front
- Ajustement des marges entres tous les tableaux (missions, signalements, zones de vigilance)
- Revue du comportement d'affichage des layers sur la carte (Amp, zones reg, zones de vigilance) -> dès qu'il n'y a plus de filtres on décoche les cases (voir capture) pour éviter d'afficher l'ensemble des couches
<img width="415" alt="Capture d’écran 2024-11-04 à 11 41 46" src="https://github.com/user-attachments/assets/824bb94d-bd00-4a43-a00f-f05b6efe4d6c">

## Related Pull Requests & Issues

- Resolve #1781 


----

- [ ] Tests E2E (Cypress)
