### PR TITLE
[Unités de contrôle] Amélioration de la recherche, zoom sur les moyens, retour en arrière depuis la fiche unité

### DIFF
--- a/frontend/src/features/ControlUnit/components/ControlUnitDialog/ControlUnitResourceList/Item.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitDialog/ControlUnitResourceList/Item.tsx
@@ -47,7 +47,7 @@ export function Item({ controlUnitResource, onEdit }: ItemProps) {
               accent={Accent.TERTIARY}
               Icon={Icon.FocusZones}
               onClick={focusOnStation}
-              title="Zommer sur la ville d'attache du moyen"
+              title="Zoom sur la ville d'attache du moyen"
             />
           </ButtonsContainer>
         </InfoBoxHeader>

--- a/frontend/src/features/ControlUnit/components/ControlUnitDialog/ControlUnitResourceList/Item.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitDialog/ControlUnitResourceList/Item.tsx
@@ -1,4 +1,7 @@
+import { useAppDispatch } from '@hooks/useAppDispatch'
 import { Accent, ControlUnit, Icon, IconButton } from '@mtes-mct/monitor-ui'
+import { mapActions } from 'domain/shared_slices/Map'
+import { fromLonLat } from 'ol/proj'
 import { useCallback } from 'react'
 import styled from 'styled-components'
 
@@ -11,12 +14,19 @@ export type ItemProps = {
   onEdit?: (controlUnitResourceId: number) => Promisable<void>
 }
 export function Item({ controlUnitResource, onEdit }: ItemProps) {
+  const dispatch = useAppDispatch()
+
   const handleEdit = useCallback(() => {
     if (!onEdit) {
       return
     }
     onEdit(controlUnitResource.id)
   }, [controlUnitResource.id, onEdit])
+
+  const focusOnStation = () => {
+    const baseCoordinate = fromLonLat([controlUnitResource.station.longitude, controlUnitResource.station.latitude])
+    dispatch(mapActions.setZoomToCenter(baseCoordinate))
+  }
 
   return (
     <Wrapper data-cy="ControlUnitDialog-control-unit-resource" data-id={controlUnitResource.id}>
@@ -29,16 +39,17 @@ export function Item({ controlUnitResource, onEdit }: ItemProps) {
             </Name>
             <p>{controlUnitResource.station.name}</p>
           </div>
-          {onEdit && (
-            <div>
-              <StyledIconButton
-                accent={Accent.TERTIARY}
-                Icon={Icon.Edit}
-                onClick={handleEdit}
-                title="Éditer ce moyen"
-              />
-            </div>
-          )}
+          <ButtonsContainer>
+            {onEdit && (
+              <IconButton accent={Accent.TERTIARY} Icon={Icon.Edit} onClick={handleEdit} title="Éditer ce moyen" />
+            )}
+            <IconButton
+              accent={Accent.TERTIARY}
+              Icon={Icon.FocusZones}
+              onClick={focusOnStation}
+              title="Zommer sur la ville d'attache du moyen"
+            />
+          </ButtonsContainer>
         </InfoBoxHeader>
         {controlUnitResource.note && <Note>{controlUnitResource.note}</Note>}
       </InfoBox>
@@ -60,28 +71,28 @@ const InfoBox = styled.div`
 `
 
 const InfoBoxHeader = styled.div`
-  display: flex;
-
-  margin-bottom: 8px;
   color: ${p => p.theme.color.gunMetal};
+  display: flex;
+  margin-bottom: 8px;
   > div:first-child {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
   }
 `
-
+const ButtonsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`
 const Note = styled.div`
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   display: -webkit-box;
-  overflow: hidden;
   margin-bottom: 4px;
+  overflow: hidden;
 `
 
 const Name = styled.p`
   font-weight: bold;
-`
-const StyledIconButton = styled(IconButton)`
-  margin-top: -5px;
 `

--- a/frontend/src/features/ControlUnit/components/ControlUnitDialog/index.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitDialog/index.tsx
@@ -1,6 +1,6 @@
 import { useGetMissionsQuery } from '@api/missionsAPI'
 import { sideWindowActions } from '@features/SideWindow/slice'
-import { Accent, Button, customDayjs, Icon, MapMenuDialog } from '@mtes-mct/monitor-ui'
+import { Accent, Button, customDayjs, Icon, IconButton, MapMenuDialog } from '@mtes-mct/monitor-ui'
 import { DateRangeEnum } from 'domain/entities/dateRange'
 import { sideWindowPaths } from 'domain/entities/sideWindow'
 import { MissionFiltersEnum, resetMissionFilters, updateFilters } from 'domain/shared_slices/MissionFilters'
@@ -72,6 +72,17 @@ export function ControlUnitDialog() {
     dispatch(sideWindowActions.focusAndGoTo(sideWindowPaths.MISSIONS))
   }
 
+  const backToList = () => {
+    dispatch(
+      globalActions.setDisplayedItems({
+        isControlUnitDialogVisible: false,
+        isControlUnitListDialogVisible: true
+      })
+    )
+    dispatch(mainWindowActions.setHasFullHeightRightDialogOpen(false))
+    dispatch(globalActions.setDisplayedItems({ isControlUnitListDialogVisible: true }))
+  }
+
   if (!controlUnit) {
     return (
       <MapMenuDialog.Container>
@@ -85,12 +96,13 @@ export function ControlUnitDialog() {
 
   return (
     <Wrapper $isRightMenuOpened={isRightMenuOpened}>
-      <MapMenuDialog.Header>
+      <StyledHeader>
+        <StyledIconButton Icon={Icon.Chevron} onClick={backToList} />
         <MapMenuDialog.Title title={`${controlUnit.name} (${controlUnit.administration.name})`}>
           <b>{controlUnit.name}</b> ({controlUnit.administration.name})
         </MapMenuDialog.Title>
         <MapMenuDialog.CloseButton Icon={Icon.Close} onClick={close} />
-      </MapMenuDialog.Header>
+      </StyledHeader>
       <Formik initialValues={controlUnit} onSubmit={noop}>
         <StyledMapMenuDialogBody>
           <Button accent={Accent.PRIMARY} Icon={Icon.Plus} isFullWidth onClick={openNewMission}>
@@ -143,6 +155,14 @@ const Wrapper = styled(MapMenuDialog.Container)<{
   z-index: 2;
 `
 
+const StyledHeader = styled(MapMenuDialog.Header)`
+  height: 48px;
+  padding: 14px 11px;
+`
+
+const StyledIconButton = styled(IconButton)`
+  transform: rotate(90deg);
+`
 const StyledMapMenuDialogBody = styled(MapMenuDialog.Body)`
   background-color: ${p => p.theme.color.gainsboro};
 

--- a/frontend/src/features/ControlUnit/components/ControlUnitDialog/index.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitDialog/index.tsx
@@ -97,7 +97,7 @@ export function ControlUnitDialog() {
   return (
     <Wrapper $isRightMenuOpened={isRightMenuOpened}>
       <StyledHeader>
-        <StyledIconButton Icon={Icon.Chevron} onClick={backToList} />
+        <StyledIconButton accent={Accent.TERTIARY} Icon={Icon.Chevron} onClick={backToList} />
         <MapMenuDialog.Title title={`${controlUnit.name} (${controlUnit.administration.name})`}>
           <b>{controlUnit.name}</b> ({controlUnit.administration.name})
         </MapMenuDialog.Title>
@@ -157,11 +157,26 @@ const Wrapper = styled(MapMenuDialog.Container)<{
 
 const StyledHeader = styled(MapMenuDialog.Header)`
   height: 48px;
-  padding: 14px 11px;
+  padding: 14px 11px 14px 8px;
 `
 
 const StyledIconButton = styled(IconButton)`
   transform: rotate(90deg);
+  color: ${p => p.theme.color.white};
+  &:hover,
+  &._hover {
+    color: ${p => p.theme.color.white};
+  }
+
+  &:active,
+  &._active {
+    color: ${p => p.theme.color.white};
+  }
+
+  &:disabled,
+  &._disabled {
+    color: ${p => p.theme.color.white};
+  }
 `
 const StyledMapMenuDialogBody = styled(MapMenuDialog.Body)`
   background-color: ${p => p.theme.color.gainsboro};

--- a/frontend/src/features/ControlUnit/components/ControlUnitListDialog/FilterBar.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitListDialog/FilterBar.tsx
@@ -1,5 +1,6 @@
 import {
   ControlUnit,
+  CustomSearch,
   Field,
   Icon,
   MultiCheckbox,
@@ -72,6 +73,24 @@ export function FilterBar() {
     [dispatch]
   )
 
+  const administrationCustomSearch = new CustomSearch(administrationsAsOptions ?? [], ['label'], {
+    cacheKey: 'CONTROL_UNIT_FILTERS_ADMINISTRATIONS',
+    isStrict: true,
+    withCacheInvalidation: true
+  })
+
+  const typeCustomSearch = new CustomSearch(typesAsOptions ?? [], ['label'], {
+    cacheKey: 'CONTROL_UNIT_FILTERS_TYPES',
+    isStrict: true,
+    withCacheInvalidation: true
+  })
+
+  const baseCustomSearch = new CustomSearch(basesAsOptions ?? [], ['label'], {
+    cacheKey: 'CONTROL_UNIT_FILTERS_BASES',
+    isStrict: true,
+    withCacheInvalidation: true
+  })
+
   if (!administrationsAsOptions || !basesAsOptions) {
     return <p>Chargement en cours...</p>
   }
@@ -90,6 +109,8 @@ export function FilterBar() {
         value={mapControlUnitListDialog.filtersState.query}
       />
       <Select
+        key={String(administrationsAsOptions.length)}
+        customSearch={administrationCustomSearch}
         isLabelHidden
         isTransparent
         label="Administration"
@@ -101,6 +122,8 @@ export function FilterBar() {
         value={mapControlUnitListDialog.filtersState.administrationId}
       />
       <Select
+        key={String(typesAsOptions.length)}
+        customSearch={typeCustomSearch}
         isLabelHidden
         isTransparent
         label="Type de moyen"
@@ -112,6 +135,8 @@ export function FilterBar() {
         value={mapControlUnitListDialog.filtersState.type}
       />
       <Select
+        key={String(basesAsOptions.length)}
+        customSearch={baseCustomSearch}
         isLabelHidden
         isTransparent
         label="Base du moyen"

--- a/frontend/src/features/ControlUnit/components/ControlUnitListDialog/index.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitListDialog/index.tsx
@@ -1,17 +1,16 @@
+import { RTK_DEFAULT_QUERY_OPTIONS } from '@api/constants'
+import { useGetControlUnitsQuery } from '@api/controlUnitsAPI'
 import { StyledMapMenuDialogContainer } from '@components/style'
+import { getFilteredControlUnits } from '@features/ControlUnit/useCases/getFilteredControlUnits'
 import { Accent, Icon, MapMenuDialog } from '@mtes-mct/monitor-ui'
 import { useCallback, useMemo } from 'react'
 
 import { FilterBar } from './FilterBar'
 import { Item } from './Item'
-import { RTK_DEFAULT_QUERY_OPTIONS } from '../../../../api/constants'
-import { useGetControlUnitsQuery } from '../../../../api/controlUnitsAPI'
 import { globalActions } from '../../../../domain/shared_slices/Global'
 import { useAppDispatch } from '../../../../hooks/useAppDispatch'
 import { useAppSelector } from '../../../../hooks/useAppSelector'
-import { isNotArchived } from '../../../../utils/isNotArchived'
 import { stationActions } from '../../../Station/slice'
-import { getFilters } from '../../utils'
 
 import type { Promisable } from 'type-fest'
 
@@ -24,17 +23,19 @@ export function ControlUnitListDialog({ onClose }: ControlUnitListDialogProps) {
   const mapControlUnitListDialog = useAppSelector(store => store.mapControlUnitListDialog)
   const { data: controlUnits } = useGetControlUnitsQuery(undefined, RTK_DEFAULT_QUERY_OPTIONS)
 
-  const activeControlUnits = useMemo(() => controlUnits?.filter(isNotArchived), [controlUnits])
-
   const filteredControlUnits = useMemo(() => {
-    if (!activeControlUnits) {
-      return undefined
+    if (!mapControlUnitListDialog.filtersState) {
+      return []
     }
 
-    const filters = getFilters(activeControlUnits, mapControlUnitListDialog.filtersState, 'MAP_CONTROL_UNIT_LIST')
+    const results = getFilteredControlUnits(
+      'MAP_CONTROL_UNIT_LIST',
+      mapControlUnitListDialog.filtersState,
+      controlUnits
+    )
 
-    return filters.reduce((previousControlUnits, filter) => filter(previousControlUnits), activeControlUnits)
-  }, [activeControlUnits, mapControlUnitListDialog.filtersState])
+    return results
+  }, [mapControlUnitListDialog.filtersState, controlUnits])
 
   const toggleBaseLayer = useCallback(() => {
     dispatch(stationActions.hightlightFeatureIds([]))

--- a/frontend/src/features/ControlUnit/useCases/getFilteredControlUnits.ts
+++ b/frontend/src/features/ControlUnit/useCases/getFilteredControlUnits.ts
@@ -1,0 +1,17 @@
+import { isNotArchived } from '@utils/isNotArchived'
+
+import { getFilters } from '../utils'
+
+import type { ControlUnit } from '@mtes-mct/monitor-ui'
+
+export const getFilteredControlUnits = (cacheKey, filtersState, controlUnits): ControlUnit.ControlUnit[] => {
+  const activeControlUnits = controlUnits?.filter(isNotArchived)
+
+  if (!activeControlUnits) {
+    return []
+  }
+
+  const filters = getFilters(activeControlUnits, filtersState, cacheKey)
+
+  return filters.reduce((previousControlUnits, filter) => filter(previousControlUnits), activeControlUnits)
+}

--- a/frontend/src/features/ControlUnit/utils.ts
+++ b/frontend/src/features/ControlUnit/utils.ts
@@ -72,7 +72,8 @@ export function getFilters(
     data,
     [
       { name: 'administration.name', weight: 0.1 },
-      { name: 'name', weight: 0.9 }
+      { name: 'name', weight: 0.9 },
+      { name: 'controlUnitResources.name', weight: 0.9 }
     ],
     {
       cacheKey,

--- a/frontend/src/features/map/MapExtentController.ts
+++ b/frontend/src/features/map/MapExtentController.ts
@@ -24,7 +24,7 @@ export function MapExtentController({ map }: BaseMapChildrenProps) {
 
   useEffect(() => {
     if (zoomToCenter) {
-      map?.getView().animate({ center: zoomToCenter, zoom: 8 })
+      map?.getView().animate({ center: zoomToCenter, zoom: 12 })
     }
   }, [map, zoomToCenter])
 


### PR DESCRIPTION
- Amélioration de la racherche par administartion, type et base (côté carte et dans les tableaux de bord)
- Ajout d'un bouton de retour depuis la fiche Unité pour retourner sur la vue liste
- Filtrer les bases sur la carte suivant les filtres appliqués dans la recherche d'unités de contrôle
- Ajout d'un zoom vers la base au niveau de chaque moyen (dans la fiche Unité)
- Ajout de la recherche par nom de moyen dans le champ de recherche


## Related Pull Requests & Issues

- Resolve #1048 
- Resolve #1758 
- Resolve #1675 

----

- [ ] Tests E2E (Cypress)
