### PR TITLE
[Listes] Correction du bug qui remontaient les listes lors du rafraîchissement des données

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/tracing": "7.114.0",
         "@svgr/webpack": "8.1.0",
         "@tanstack/react-table": "8.20.5",
-        "@tanstack/react-virtual": "beta",
+        "@tanstack/react-virtual": "3.10.9",
         "classnames": "2.5.1",
         "compressorjs": "1.2.1",
         "dayjs": "1.11.13",
@@ -4791,11 +4791,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.0.0-beta.68",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.68.tgz",
-      "integrity": "sha512-YEFNCf+N3ZlNou2r4qnh+GscMe24foYEjTL05RS0ZHvah2RoUDPGuhnuedTv0z66dO2vIq6+Bl4TXatht5T7GQ==",
+      "version": "3.10.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.10.9.tgz",
+      "integrity": "sha512-OXO2uBjFqA4Ibr2O3y0YMnkrRWGVNqcvHQXmGvMu6IK8chZl3PrDxFXdGZ2iZkSrKh3/qUYoFqYe+Rx23RoU0g==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.0.0-beta.68"
+        "@tanstack/virtual-core": "3.10.9"
       },
       "funding": {
         "type": "github",
@@ -4819,9 +4820,10 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.0.0-beta.68",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.68.tgz",
-      "integrity": "sha512-CnvsEJWK7cugigckt13AeY80FMzH+OMdEP0j0bS3/zjs44NiRe49x8FZC6R9suRXGMVMXtUHet0zbTp/Ec9Wfg==",
+      "version": "3.10.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.10.9.tgz",
+      "integrity": "sha512-kBknKOKzmeR7lN+vSadaKWXaLS0SZZG+oqpQ/k80Q6g9REn6zRHS/ZYdrIzHnpHgy/eWs00SujveUN/GJT2qTw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@sentry/tracing": "7.114.0",
     "@svgr/webpack": "8.1.0",
     "@tanstack/react-table": "8.20.5",
-    "@tanstack/react-virtual": "beta",
+    "@tanstack/react-virtual": "3.10.9",
     "classnames": "2.5.1",
     "compressorjs": "1.2.1",
     "dayjs": "1.11.13",

--- a/frontend/src/features/Dashboard/components/DashboardsList/Columns/index.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardsList/Columns/index.tsx
@@ -1,5 +1,6 @@
 import { DateCell } from '@components/Table/DateCell'
 import { LocalizeCell } from '@components/Table/LocalizeCell'
+import { StyledSkeletonRow } from '@features/commonComponents/Skeleton'
 import { type Row } from '@tanstack/react-table'
 
 import { ControlUnitsCell } from '../Rows/ControlUnitsCell'
@@ -8,11 +9,18 @@ import { RegulatoryAreasThemesCell } from '../Rows/RegulatoryAreasThemesCell'
 import { TotalSelectedItemsCell } from '../Rows/TotalSelectedItemsCell'
 
 import type { Dashboard } from '@features/Dashboard/types'
+import type { ControlUnit } from '@mtes-mct/monitor-ui'
+import type { RegulatoryLayerCompactFromAPI } from 'domain/entities/regulatory'
 
-export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: number = 0) => [
+export const Columns = (
+  regulatoryAreas: RegulatoryLayerCompactFromAPI[],
+  controlUnits: ControlUnit.ControlUnit[] | undefined,
+  legacyFirefoxOffset: number = 0,
+  isFetching: boolean = false
+) => [
   {
     accessorFn: row => row.seaFront,
-    cell: info => info.getValue(),
+    cell: info => (isFetching ? <StyledSkeletonRow /> : info.getValue()),
     enableSorting: true,
     header: () => 'Façade',
     id: 'seaFront',
@@ -20,7 +28,7 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
   },
   {
     accessorFn: row => row.name,
-    cell: info => info.getValue(),
+    cell: info => (isFetching ? <StyledSkeletonRow /> : info.getValue()),
     enableSorting: true,
     header: () => 'Nom',
     id: 'name',
@@ -28,7 +36,7 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
   },
   {
     accessorFn: row => row.createdAt,
-    cell: info => <DateCell date={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <DateCell date={info.getValue()} />),
     enableSorting: true,
     header: () => 'Créé le ...',
     id: 'createdAt',
@@ -36,7 +44,7 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
   },
   {
     accessorFn: row => row.updatedAt,
-    cell: info => <DateCell date={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <DateCell date={info.getValue()} />),
     enableSorting: true,
     header: () => 'Mis à jour le ...',
     id: 'updatedAt',
@@ -44,7 +52,7 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
   },
   {
     accessorFn: row => row.controlUnitIds,
-    cell: info => <ControlUnitsCell controlUnitIds={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <ControlUnitsCell controlUnitIds={info.getValue()} />),
     enableSorting: true,
     header: () => 'Unité (Administration)',
     id: 'controlUnitIds',
@@ -62,7 +70,7 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
   },
   {
     accessorFn: row => row.regulatoryAreaIds,
-    cell: info => <RegulatoryAreasThemesCell themeIds={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <RegulatoryAreasThemesCell themeIds={info.getValue()} />),
     enableSorting: true,
     header: () => 'Thématiques',
     id: 'regulatoryAreaIds',
@@ -71,15 +79,15 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
       const themeIdA = rowA.original[columnId][0]
       const themeIdB = rowB.original[columnId][0]
 
-      const themeA: string = regulatoryAreas?.entities[themeIdA]?.layer_name ?? ''
-      const themeB: string = regulatoryAreas?.entities[themeIdB]?.layer_name ?? ''
+      const themeA: string = regulatoryAreas?.[themeIdA]?.layer_name ?? ''
+      const themeB: string = regulatoryAreas?.[themeIdB]?.layer_name ?? ''
 
       return themeA?.localeCompare(themeB)
     }
   },
   {
     accessorFn: row => row,
-    cell: ({ row }) => <TotalSelectedItemsCell row={row} />,
+    cell: ({ row }) => (isFetching ? <StyledSkeletonRow /> : <TotalSelectedItemsCell row={row} />),
     enableSorting: true,
     header: () => "Nb d'éléments sélectionnés",
     id: 'totalSelectedItems',
@@ -106,7 +114,7 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
   },
   {
     accessorFn: row => row.geom,
-    cell: info => <LocalizeCell geom={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <LocalizeCell geom={info.getValue()} />),
     enableSorting: false,
     header: () => '',
     id: 'geom',
@@ -114,7 +122,7 @@ export const Columns = (regulatoryAreas, controlUnits, legacyFirefoxOffset: numb
   },
   {
     accessorFn: row => row.id,
-    cell: info => <EditDashboardCell id={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <EditDashboardCell id={info.getValue()} />),
     enableSorting: false,
     header: () => '',
     id: 'edit',

--- a/frontend/src/features/Dashboard/components/DashboardsList/DashboardsTable.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardsList/DashboardsTable.tsx
@@ -16,10 +16,11 @@ import type { Dashboard } from '@features/Dashboard/types'
 
 interface DashboardsTableProps {
   dashboards: Dashboard.Dashboard[]
+  isFetching: boolean
   isLoading: boolean
 }
 
-export function DashboardsTable({ dashboards, isLoading }: DashboardsTableProps) {
+export function DashboardsTable({ dashboards, isFetching, isLoading }: DashboardsTableProps) {
   const tableContainerRef = useRef<HTMLDivElement>(null)
 
   const { pathname } = useLocation()
@@ -31,16 +32,17 @@ export function DashboardsTable({ dashboards, isLoading }: DashboardsTableProps)
   const columns = useMemo(
     () =>
       isLoading
-        ? Columns(regulatoryAreas, controlUnits, legacyFirefoxOffset).map(column => ({
-            ...column,
-            cell: StyledSkeletonRow
-          }))
-        : Columns(regulatoryAreas, controlUnits, legacyFirefoxOffset),
-    [isLoading, controlUnits, regulatoryAreas, legacyFirefoxOffset]
+        ? Columns(Object.values(regulatoryAreas?.entities ?? {}), controlUnits, legacyFirefoxOffset, false).map(
+            column => ({
+              ...column,
+              cell: StyledSkeletonRow
+            })
+          )
+        : Columns(Object.values(regulatoryAreas?.entities ?? {}), controlUnits, legacyFirefoxOffset, isFetching),
+    [isFetching, isLoading, controlUnits, regulatoryAreas, legacyFirefoxOffset]
   )
 
   const [sorting, setSorting] = useState<SortingState>([{ desc: true, id: 'updatedAt' }])
-
   const tableData = useMemo(() => (isLoading ? Array(5).fill({}) : dashboards), [isLoading, dashboards])
 
   const table = useTable({

--- a/frontend/src/features/Dashboard/components/DashboardsList/index.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardsList/index.tsx
@@ -4,9 +4,15 @@ import { SideWindowContent } from '@features/SideWindow/style'
 import styled from 'styled-components'
 
 import { DashboardsTable } from './DashboardsTable'
+import { TWO_MINUTES } from '../../../../constants'
 
 export function DashboardsList() {
-  const { data: dashboards, isError, isFetching, isLoading } = useGetDashboardsQuery()
+  const {
+    data: dashboards,
+    isError,
+    isFetching,
+    isLoading
+  } = useGetDashboardsQuery(undefined, { pollingInterval: TWO_MINUTES })
 
   return (
     <SideWindowContent>
@@ -20,7 +26,7 @@ export function DashboardsList() {
       {isError ? (
         <p>Erreur au chargement des données</p>
       ) : (
-        <DashboardsTable dashboards={dashboards ?? []} isLoading={isLoading || isFetching} />
+        <DashboardsTable dashboards={dashboards ?? []} isFetching={isFetching} isLoading={isLoading} />
       )}
     </SideWindowContent>
   )

--- a/frontend/src/features/Dashboard/components/Layers/ActiveDashboardLayer.tsx
+++ b/frontend/src/features/Dashboard/components/Layers/ActiveDashboardLayer.tsx
@@ -32,10 +32,12 @@ export function ActiveDashboardLayer({ map }: BaseMapChildrenProps) {
   const activeDashboardId = useAppSelector(state => state.dashboard.activeDashboardId)
 
   const dashboard = useAppSelector(state => getDashboardById(state.dashboard, activeDashboardId))
-  const { data: reportings } = useGetReportingsByIdsQuery(dashboard?.dashboard.reportingIds ?? [])
-  const { data: regulatoryLayers } = useGetRegulatoryLayersQuery()
-  const { data: ampLayers } = useGetAMPsQuery()
-  const { data: vigilanceAreas } = useGetVigilanceAreasQuery()
+  const { data: reportings } = useGetReportingsByIdsQuery(dashboard?.dashboard.reportingIds ?? [], {
+    skip: !dashboard
+  })
+  const { data: regulatoryLayers } = useGetRegulatoryLayersQuery(undefined, { skip: !dashboard })
+  const { data: ampLayers } = useGetAMPsQuery(undefined, { skip: !dashboard })
+  const { data: vigilanceAreas } = useGetVigilanceAreasQuery(undefined, { skip: !dashboard })
 
   const openPanel = dashboard?.openPanel
   const activeDashboard = dashboard?.dashboard

--- a/frontend/src/features/Dashboard/components/Layers/PreviewDashboardLayer.tsx
+++ b/frontend/src/features/Dashboard/components/Layers/PreviewDashboardLayer.tsx
@@ -40,9 +40,9 @@ export function DashboardPreviewLayer({ map }: BaseMapChildrenProps) {
     },
     [openPanel]
   )
-  const { data: regulatoryLayers } = useGetRegulatoryLayersQuery()
-  const { data: ampLayers } = useGetAMPsQuery()
-  const { data: vigilanceAreas } = useGetVigilanceAreasQuery()
+  const { data: regulatoryLayers } = useGetRegulatoryLayersQuery(undefined, { skip: !dashboard })
+  const { data: ampLayers } = useGetAMPsQuery(undefined, { skip: !dashboard })
+  const { data: vigilanceAreas } = useGetVigilanceAreasQuery(undefined, { skip: !dashboard })
 
   const previewLayersVectorSourceRef = useRef(new VectorSource()) as React.MutableRefObject<
     VectorSource<Feature<Geometry>>

--- a/frontend/src/features/Reportings/components/ReportingsList/Columns/index.tsx
+++ b/frontend/src/features/Reportings/components/ReportingsList/Columns/index.tsx
@@ -1,5 +1,6 @@
 import { DateCell } from '@components/Table/DateCell'
 import { LocalizeCell } from '@components/Table/LocalizeCell'
+import { StyledSkeletonRow } from '@features/commonComponents/Skeleton'
 import { getFormattedReportingId, sortTargetDetails } from '@features/Reportings/utils'
 import { TableWithSelectableRows } from '@mtes-mct/monitor-ui'
 import styled from 'styled-components'
@@ -15,7 +16,7 @@ import { getReportType } from '../Cells/getReportType'
 
 import type { Row } from '@tanstack/react-table'
 
-export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
+export const Columns = (themes, legacyFirefoxOffset: number = 0, isFetching: boolean = false) => [
   {
     accessorFn: row => row.reportingId,
     cell: ({ row }) => (
@@ -39,7 +40,8 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.reportingId,
-    cell: info => <Cell id={info.getValue()}>{getFormattedReportingId(info.getValue())}</Cell>,
+    cell: info =>
+      isFetching ? <StyledSkeletonRow /> : <Cell id={info.getValue()}>{getFormattedReportingId(info.getValue())}</Cell>,
     enableSorting: false,
     header: () => '',
     id: 'reportingId',
@@ -47,7 +49,7 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.createdAt,
-    cell: info => <DateCell date={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <DateCell date={info.getValue()} />),
     enableSorting: true,
     header: () => 'Date (UTC)',
     id: 'createdAt',
@@ -55,7 +57,7 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.validityTime,
-    cell: ({ row }) => <CellValidityTime row={row} />,
+    cell: ({ row }) => (isFetching ? <StyledSkeletonRow /> : <CellValidityTime row={row} />),
     enableSorting: false, // TODO see how we can sort on timeLeft and not validityTime
     header: () => 'Fin dans',
     id: 'validityTime',
@@ -63,11 +65,14 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.reportingSources?.map(source => source.displayedSource).join(', '),
-    cell: info => (
-      <Cell id={info.getValue()} title={info.getValue()}>
-        {info.getValue()}
-      </Cell>
-    ),
+    cell: info =>
+      isFetching ? (
+        <StyledSkeletonRow />
+      ) : (
+        <Cell id={info.getValue()} title={info.getValue()}>
+          {info.getValue()}
+        </Cell>
+      ),
     enableSorting: true,
     header: () => 'Source',
     id: 'displayedSource',
@@ -75,7 +80,7 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.reportType,
-    cell: info => getReportType(info.getValue()),
+    cell: info => (isFetching ? <StyledSkeletonRow /> : getReportType(info.getValue())),
     enableSorting: true,
     header: () => 'Type',
     id: 'reportType',
@@ -83,14 +88,17 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.targetDetails,
-    cell: ({ row }) => (
-      <CellTarget
-        description={row.original.description}
-        targetDetails={row.original.targetDetails}
-        targetType={row.original.targetType}
-        vehicleType={row.original.vehicleType}
-      />
-    ),
+    cell: ({ row }) =>
+      isFetching ? (
+        <StyledSkeletonRow />
+      ) : (
+        <CellTarget
+          description={row.original.description}
+          targetDetails={row.original.targetDetails}
+          targetType={row.original.targetType}
+          vehicleType={row.original.vehicleType}
+        />
+      ),
     header: () => 'Cible',
     id: 'targetDetails',
     size: 190 + legacyFirefoxOffset,
@@ -98,7 +106,12 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.theme,
-    cell: ({ row }) => <CellActionThemes subThemeIds={row.original.subThemeIds} themeId={row.original.themeId} />,
+    cell: ({ row }) =>
+      isFetching ? (
+        <StyledSkeletonRow />
+      ) : (
+        <CellActionThemes subThemeIds={row.original.subThemeIds} themeId={row.original.themeId} />
+      ),
     enableSorting: true,
     header: () => 'Thématique',
     id: 'themeId',
@@ -112,7 +125,7 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.seaFront,
-    cell: info => <Cell id={info.getValue()}>{info.getValue()}</Cell>,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <Cell id={info.getValue()}>{info.getValue()}</Cell>),
     enableSorting: true,
     header: () => 'Façade',
     id: 'seaFront',
@@ -120,7 +133,7 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.status,
-    cell: ({ row }) => <CellStatus row={row} />,
+    cell: ({ row }) => (isFetching ? <StyledSkeletonRow /> : <CellStatus row={row} />),
     enableSorting: true,
     header: () => 'Statut',
     id: 'isArchived',
@@ -138,12 +151,15 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.missionId,
-    cell: ({ row }) => (
-      <CellAttachedtoMission
-        detachedFromMissionAtUtc={row.original.detachedFromMissionAtUtc}
-        missionId={row.original.missionId}
-      />
-    ),
+    cell: ({ row }) =>
+      isFetching ? (
+        <StyledSkeletonRow />
+      ) : (
+        <CellAttachedtoMission
+          detachedFromMissionAtUtc={row.original.detachedFromMissionAtUtc}
+          missionId={row.original.missionId}
+        />
+      ),
     enableSorting: false,
     header: () => '',
     id: 'missionId',
@@ -151,14 +167,17 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.geom,
-    cell: ({ row }) => (
-      <CellActionStatus
-        controlStatus={row.original.controlStatus}
-        detachedFromMissionAtUtc={row.original.detachedFromMissionAtUtc}
-        isControlRequired={row.original.isControlRequired}
-        missionId={row.original.missionId}
-      />
-    ),
+    cell: ({ row }) =>
+      isFetching ? (
+        <StyledSkeletonRow />
+      ) : (
+        <CellActionStatus
+          controlStatus={row.original.controlStatus}
+          detachedFromMissionAtUtc={row.original.detachedFromMissionAtUtc}
+          isControlRequired={row.original.isControlRequired}
+          missionId={row.original.missionId}
+        />
+      ),
     enableSorting: false,
     header: () => '',
     id: 'actionStatus',
@@ -166,7 +185,7 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.geom,
-    cell: info => <LocalizeCell geom={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <LocalizeCell geom={info.getValue()} />),
     enableSorting: false,
     header: () => '',
     id: 'geom',
@@ -174,7 +193,7 @@ export const Columns = (themes, legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.id,
-    cell: info => <ButtonsGroupRow id={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <ButtonsGroupRow id={info.getValue()} />),
     enableSorting: false,
     header: () => '',
     id: 'id',

--- a/frontend/src/features/Reportings/components/ReportingsList/ReportingsTable.tsx
+++ b/frontend/src/features/Reportings/components/ReportingsList/ReportingsTable.tsx
@@ -18,9 +18,11 @@ import { GroupActions } from './GroupActions'
 import type { Reporting } from 'domain/entities/reporting'
 
 export function ReportingsTable({
+  isFetching,
   isLoading,
   reportings
 }: {
+  isFetching: boolean
   isLoading: boolean
   reportings: (Reporting | undefined)[]
 }) {
@@ -33,15 +35,15 @@ export function ReportingsTable({
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const [sorting, setSorting] = useState<SortingState>([{ desc: true, id: 'createdAt' }])
 
-  const tableData = useMemo(() => (isLoading ? Array(5).fill({}) : reportings), [isLoading, reportings])
-
   const columns = useMemo(
     () =>
       isLoading
-        ? Columns(themes, legacyFirefoxOffset).map(column => ({ ...column, cell: StyledSkeletonRow }))
-        : Columns(themes, legacyFirefoxOffset),
-    [isLoading, legacyFirefoxOffset, themes]
+        ? Columns(themes, legacyFirefoxOffset, false).map(column => ({ ...column, cell: StyledSkeletonRow }))
+        : Columns(themes, legacyFirefoxOffset, isFetching),
+    [isLoading, isFetching, legacyFirefoxOffset, themes]
   )
+
+  const tableData = useMemo(() => (isLoading ? Array(5).fill({}) : reportings), [isLoading, reportings])
 
   const table = useTable({
     columns,

--- a/frontend/src/features/Reportings/components/ReportingsList/index.tsx
+++ b/frontend/src/features/Reportings/components/ReportingsList/index.tsx
@@ -33,7 +33,7 @@ export function ReportingsList() {
       {isError ? (
         <p data-cy="listReportingWrapper">Erreur au chargement des données</p>
       ) : (
-        <ReportingsTable isLoading={isLoading || isFetching} reportings={reportings} />
+        <ReportingsTable isFetching={isFetching} isLoading={isLoading} reportings={reportings} />
       )}
     </SideWindowContent>
   )

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Columns/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/Columns/index.tsx
@@ -1,4 +1,5 @@
 import { DateCell } from '@components/Table/DateCell'
+import { StyledSkeletonRow } from '@features/commonComponents/Skeleton'
 import { VigilanceArea } from '@features/VigilanceArea/types'
 
 import { EditCell } from '../Rows/EditCell'
@@ -9,10 +10,10 @@ import { StatusCell } from '../Rows/StatusCell'
 
 import type { Row } from '@tanstack/react-table'
 
-export const Columns = (legacyFirefoxOffset: number = 0) => [
+export const Columns = (legacyFirefoxOffset: number = 0, isFetching: boolean = false) => [
   {
     accessorFn: row => row.startDatePeriod,
-    cell: info => <DateCell date={info.getValue()} withoutTime />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <DateCell date={info.getValue()} withoutTime />),
     enableSorting: true,
     header: () => 'Début',
     id: 'startDatePeriod',
@@ -20,7 +21,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.endDatePeriod,
-    cell: info => <DateCell date={info.getValue()} withoutTime />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <DateCell date={info.getValue()} withoutTime />),
     enableSorting: true,
     header: () => 'Fin',
     id: 'endDatePeriod',
@@ -28,7 +29,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.frequency,
-    cell: info => <FrequencyCell frequency={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <FrequencyCell frequency={info.getValue()} />),
     enableSorting: true,
     header: () => 'Récurrence',
     id: 'frequency',
@@ -42,7 +43,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.name,
-    cell: info => <HighlightCell text={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <HighlightCell text={info.getValue()} />),
     enableSorting: true,
     header: () => 'Nom de la zone',
     id: 'name',
@@ -50,9 +51,12 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.themes?.join(', '),
-    cell: info => (
-      <span title={info.getValue()}>{info.getValue() && info.getValue().length > 0 ? info.getValue() : '-'}</span>
-    ),
+    cell: info =>
+      isFetching ? (
+        <StyledSkeletonRow />
+      ) : (
+        <span title={info.getValue()}>{info.getValue() && info.getValue().length > 0 ? info.getValue() : '-'}</span>
+      ),
     enableSorting: true,
     header: () => 'Thématique',
     id: 'themes',
@@ -60,7 +64,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.comments,
-    cell: info => <HighlightCell text={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <HighlightCell text={info.getValue()} />),
     enableSorting: true,
     header: () => 'Commentaire',
     id: 'comments',
@@ -68,7 +72,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.seaFront,
-    cell: info => info.getValue() ?? '-',
+    cell: info => (isFetching ? <StyledSkeletonRow /> : info.getValue() ?? '-'),
     enableSorting: true,
     header: () => 'Façade',
     id: 'seaFront',
@@ -76,7 +80,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.isDraft,
-    cell: info => <StatusCell isDraft={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <StatusCell isDraft={info.getValue()} />),
     enableSorting: true,
     header: () => 'Statut',
     id: 'isDraft',
@@ -84,7 +88,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.createdBy,
-    cell: info => info.getValue() ?? '-',
+    cell: info => (isFetching ? <StyledSkeletonRow /> : info.getValue() ?? '-'),
     enableSorting: true,
     header: () => 'Créée par',
     id: 'createdBy',
@@ -92,7 +96,8 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.geom,
-    cell: ({ row }) => <LocalizeCell geom={row.original.geom} id={row.original.id} />,
+    cell: ({ row }) =>
+      isFetching ? <StyledSkeletonRow /> : <LocalizeCell geom={row.original.geom} id={row.original.id} />,
     enableSorting: false,
     header: () => '',
     id: 'geom',
@@ -100,7 +105,8 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.id,
-    cell: ({ row }) => <EditCell geom={row.original.geom} id={row.original.id} />,
+    cell: ({ row }) =>
+      isFetching ? <StyledSkeletonRow /> : <EditCell geom={row.original.geom} id={row.original.id} />,
     enableSorting: false,
     header: () => '',
     id: 'edit',

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/VigilanceAreasTable.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/VigilanceAreasTable.tsx
@@ -15,9 +15,11 @@ import { Columns } from './Columns'
 import type { VigilanceArea } from '@features/VigilanceArea/types'
 
 export function VigilanceAreasTable({
+  isFetching,
   isLoading,
   vigilanceAreas
 }: {
+  isFetching: boolean
   isLoading: boolean
   vigilanceAreas: VigilanceArea.VigilanceArea[]
 }) {
@@ -27,15 +29,15 @@ export function VigilanceAreasTable({
 
   const [sorting, setSorting] = useState<SortingState>([{ desc: true, id: 'name' }])
 
-  const tableData = useMemo(() => (isLoading ? Array(5).fill({}) : vigilanceAreas), [isLoading, vigilanceAreas])
-
   const columns = useMemo(
     () =>
       isLoading
-        ? Columns(legacyFirefoxOffset).map(column => ({ ...column, cell: StyledSkeletonRow }))
-        : Columns(legacyFirefoxOffset),
-    [isLoading, legacyFirefoxOffset]
+        ? Columns(legacyFirefoxOffset, false).map(column => ({ ...column, cell: StyledSkeletonRow }))
+        : Columns(legacyFirefoxOffset, isFetching),
+    [isLoading, isFetching, legacyFirefoxOffset]
   )
+
+  const tableData = useMemo(() => (isLoading ? Array(5).fill({}) : vigilanceAreas), [isLoading, vigilanceAreas])
 
   const table = useTable({
     columns,

--- a/frontend/src/features/VigilanceArea/components/VigilanceAreasList/index.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreasList/index.tsx
@@ -26,7 +26,7 @@ export function VigilancesAreasList() {
             'zone',
             vigilanceAreasResults.length ?? 0
           )} de vigilance`}</TotalResults>
-          <VigilanceAreasTable isLoading={isLoading || isFetching} vigilanceAreas={vigilanceAreasResults} />
+          <VigilanceAreasTable isFetching={isFetching} isLoading={isLoading} vigilanceAreas={vigilanceAreasResults} />
         </>
       )}
     </SideWindowContent>

--- a/frontend/src/features/missions/MissionsList/Columns/index.tsx
+++ b/frontend/src/features/missions/MissionsList/Columns/index.tsx
@@ -1,5 +1,6 @@
 import { DateCell } from '@components/Table/DateCell'
 import { LocalizeCell } from '@components/Table/LocalizeCell'
+import { StyledSkeletonRow } from '@features/commonComponents/Skeleton'
 
 import { CellActionThemes } from '../CellActionThemes'
 import { CellCompletionStatus } from '../CellCompletionStatus'
@@ -12,10 +13,10 @@ import { sortCompletion, sortNumberOfControls, sortStatus } from '../utils'
 
 import type { Row } from '@tanstack/react-table'
 
-export const Columns = (legacyFirefoxOffset: number = 0) => [
+export const Columns = (legacyFirefoxOffset: number = 0, isFetching = false) => [
   {
     accessorFn: row => row.startDateTimeUtc,
-    cell: info => <DateCell date={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <DateCell date={info.getValue()} />),
     enableSorting: true,
     header: () => 'Début',
     id: 'startDate',
@@ -23,7 +24,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.endDateTimeUtc,
-    cell: info => <DateCell date={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <DateCell date={info.getValue()} />),
     enableSorting: true,
     header: () => 'Fin',
     id: 'endDate',
@@ -31,7 +32,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.facade,
-    cell: info => info.getValue(),
+    cell: info => (isFetching ? <StyledSkeletonRow /> : info.getValue()),
     enableSorting: true,
     header: () => 'Façade',
     id: 'seaFront',
@@ -39,7 +40,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.missionTypes,
-    cell: info => getMissionTypeCell(info.getValue()),
+    cell: info => (isFetching ? <StyledSkeletonRow /> : getMissionTypeCell(info.getValue())),
     enableSorting: false,
     header: () => 'Type',
     id: 'type',
@@ -47,7 +48,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.controlUnits,
-    cell: info => getResourcesCell(info.getValue()),
+    cell: info => (isFetching ? <StyledSkeletonRow /> : getResourcesCell(info.getValue())),
     enableSorting: false,
     header: () => 'Unité (Administration)',
     id: 'unitAndAdministration',
@@ -56,7 +57,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
 
   {
     accessorFn: row => row.envActions,
-    cell: info => <CellActionThemes envActions={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <CellActionThemes envActions={info.getValue()} />),
     enableSorting: false,
     header: () => 'Thématiques',
     id: 'themes',
@@ -64,7 +65,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.envActions,
-    cell: info => getNumberOfControlsCell(info.getValue()),
+    cell: info => (isFetching ? <StyledSkeletonRow /> : getNumberOfControlsCell(info.getValue())),
     header: () => 'Ctr.',
     id: 'envActions',
     size: 75 + legacyFirefoxOffset,
@@ -72,7 +73,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row,
-    cell: ({ row }) => <CellStatus row={row} />,
+    cell: ({ row }) => (isFetching ? <StyledSkeletonRow /> : <CellStatus row={row} />),
     header: () => 'Statut',
     id: 'status',
     size: 121 + legacyFirefoxOffset,
@@ -80,7 +81,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row,
-    cell: ({ row }) => <CellCompletionStatus row={row} />,
+    cell: ({ row }) => (isFetching ? <StyledSkeletonRow /> : <CellCompletionStatus row={row} />),
     header: () => 'État données',
     id: 'completion',
     size: 144 + legacyFirefoxOffset,
@@ -88,7 +89,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.geom,
-    cell: info => <LocalizeCell geom={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <LocalizeCell geom={info.getValue()} />),
     enableSorting: false,
     header: () => '',
     id: 'geom',
@@ -96,7 +97,7 @@ export const Columns = (legacyFirefoxOffset: number = 0) => [
   },
   {
     accessorFn: row => row.id,
-    cell: info => <CellEditMission id={info.getValue()} />,
+    cell: info => (isFetching ? <StyledSkeletonRow /> : <CellEditMission id={info.getValue()} />),
     enableSorting: false,
     header: () => '',
     id: 'edit',

--- a/frontend/src/features/missions/MissionsList/MissionsTable.tsx
+++ b/frontend/src/features/missions/MissionsList/MissionsTable.tsx
@@ -1,4 +1,5 @@
 import { Table } from '@components/Table'
+import { StyledSkeletonRow } from '@features/commonComponents/Skeleton'
 import { useTable } from '@hooks/useTable'
 import { useTableVirtualizer } from '@hooks/useTableVirtualizer'
 import { type SortingState } from '@tanstack/react-table'
@@ -8,11 +9,16 @@ import { useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
 import { Columns } from './Columns'
-import { StyledSkeletonRow } from '../../commonComponents/Skeleton'
 
 import type { Mission } from '../../../domain/entities/missions'
 
-export function MissionsTable({ isLoading, missions }: { isLoading: boolean; missions: Mission[] }) {
+type MissionsTableProps = {
+  isFetching: boolean
+  isLoading: boolean
+  missions: Mission[]
+}
+
+export function MissionsTable({ isFetching, isLoading, missions }: MissionsTableProps) {
   const tableContainerRef = useRef<HTMLDivElement>(null)
 
   const { pathname } = useLocation()
@@ -23,9 +29,9 @@ export function MissionsTable({ isLoading, missions }: { isLoading: boolean; mis
   const columns = useMemo(
     () =>
       isLoading
-        ? Columns(legacyFirefoxOffset).map(column => ({ ...column, cell: StyledSkeletonRow }))
-        : Columns(legacyFirefoxOffset),
-    [isLoading, legacyFirefoxOffset]
+        ? Columns(legacyFirefoxOffset, false).map(column => ({ ...column, cell: StyledSkeletonRow }))
+        : Columns(legacyFirefoxOffset, isFetching),
+    [isLoading, isFetching, legacyFirefoxOffset]
   )
 
   const tableData = useMemo(() => (isLoading ? Array(5).fill({}) : missions), [isLoading, missions])

--- a/frontend/src/features/missions/MissionsList/index.tsx
+++ b/frontend/src/features/missions/MissionsList/index.tsx
@@ -34,7 +34,7 @@ export function Missions() {
       {isError ? (
         <p data-cy="listMissionWrapper">Erreur au chargement des données</p>
       ) : (
-        <MissionsTable isLoading={isLoading || isFetching} missions={missions} />
+        <MissionsTable isFetching={isFetching} isLoading={isLoading} missions={missions} />
       )}
     </SideWindowContent>
   )

--- a/frontend/src/hooks/useTable.ts
+++ b/frontend/src/hooks/useTable.ts
@@ -32,6 +32,7 @@ export function useTable({
     enableRowSelection: withRowSelection,
     enableSortingRemoval: false,
     getCoreRowModel: getCoreRowModel(),
+    getRowId: (row: any) => row.id,
     getSortedRowModel: getSortedRowModel(),
     onRowSelectionChange: withRowSelection ? setRowSelection : undefined,
     onSortingChange: setSorting,


### PR DESCRIPTION
-  `isLoading` est a `true` au premier appel api => on affiche un tableau avec le Skeleton
- `isFetching` est a `true` lors du refetch des datas => on change les cellules pour éviter de re-render le tableau complètement et qu'il scroll tout en haut

## Related Pull Requests & Issues

- Resolve #1454

----

- [ ] Tests E2E (Cypress)
