### PR TITLE
[Unité de contrôle] Retours UX

### DIFF
--- a/frontend/src/features/ControlUnit/components/ControlUnitDialog/ControlUnitResourceList/Item.tsx
+++ b/frontend/src/features/ControlUnit/components/ControlUnitDialog/ControlUnitResourceList/Item.tsx
@@ -1,5 +1,7 @@
+import { stationActions } from '@features/Station/slice'
 import { useAppDispatch } from '@hooks/useAppDispatch'
 import { Accent, ControlUnit, Icon, IconButton } from '@mtes-mct/monitor-ui'
+import { Layers } from 'domain/entities/layers/constants'
 import { mapActions } from 'domain/shared_slices/Map'
 import { fromLonLat } from 'ol/proj'
 import { useCallback } from 'react'
@@ -24,8 +26,10 @@ export function Item({ controlUnitResource, onEdit }: ItemProps) {
   }, [controlUnitResource.id, onEdit])
 
   const focusOnStation = () => {
-    const baseCoordinate = fromLonLat([controlUnitResource.station.longitude, controlUnitResource.station.latitude])
+    const { station } = controlUnitResource
+    const baseCoordinate = fromLonLat([station.longitude, station.latitude])
     dispatch(mapActions.setZoomToCenter(baseCoordinate))
+    dispatch(stationActions.hightlightFeatureIds([`${Layers.STATIONS.code}:${station.id}`]))
   }
 
   return (

--- a/frontend/src/features/Station/components/StationOverlay/StationCard/index.tsx
+++ b/frontend/src/features/Station/components/StationOverlay/StationCard/index.tsx
@@ -1,4 +1,5 @@
 import { type ControlUnit, MapMenuDialog } from '@mtes-mct/monitor-ui'
+import { isNotArchived } from '@utils/isNotArchived'
 import { uniq } from 'lodash/fp'
 import { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
@@ -54,7 +55,9 @@ export function StationCard({ feature, selected = false }: { feature: FeatureLik
         return controlUnit
       })
     )
-    setControlUnits(controlUnitsFromApi)
+    const filteredControlUnits = controlUnitsFromApi?.filter(isNotArchived)
+
+    setControlUnits(filteredControlUnits)
   }, [dispatch, featureProperties.station])
 
   useEffect(() => {


### PR DESCRIPTION
- Au moment de zoomer sur une base depuis un moyen, mettre l'icône de base en bleu
- Ne plus afficher les unités de contrôle archivées dans la liste des unités d'une base

## Related Pull Requests & Issues

- Resolve #1834
- Resolve #1758

----

- [ ] Tests E2E (Cypress)
