### PR TITLE
[Reporting] Pouvoir fermer la pop-up de rattachement d'une signalement à une mission

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,23 +1,9 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-import { isCypress } from '@utils/isCypress'
 
 import { setAuthorizationHeader } from './utils/setAuthorizationHeaders'
 import { normalizeRtkBaseQuery } from '../utils/normalizeRtkBaseQuery'
 
 import type { BackendApiErrorResponse } from './types'
-
-// =============================================================================
-// GeoServer API
-
-const geoserverURL = isCypress()
-  ? window.Cypress.env('CYPRESS_FRONTEND_GEOSERVER_REMOTE_URL')
-  : import.meta.env.FRONTEND_REPORTING_FORM_AUTO_SAVE_ENABLED
-
-export const geoserverApi = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: `${geoserverURL}/geoserver` }),
-  endpoints: () => ({}),
-  reducerPath: 'geoserverApi'
-})
 
 // =============================================================================
 // Monitorenv Private API

--- a/frontend/src/features/Reportings/components/ReportingForm/AttachMission/AttachMissionToReportingModal.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/AttachMission/AttachMissionToReportingModal.tsx
@@ -26,12 +26,18 @@ export function AttachMissionToReportingModal() {
     dispatch(updateMapInteractionListeners(MapInteractionListenerEnum.NONE))
   }
 
+  const cancel = () => {
+    dispatch(attachMissionToReportingSliceActions.setAttachedMission(initialAttachedMission))
+    dispatch(updateMapInteractionListeners(MapInteractionListenerEnum.NONE))
+  }
+
   if (!isMissionAttachmentInProgress) {
     return null
   }
 
   return (
     <MapInteraction
+      onCancel={cancel}
       onReset={resetMissionToAttach}
       onValidate={validateMissionToAttach}
       title="Vous êtes en train de lier ce signalement à une mission"

--- a/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
@@ -3,7 +3,7 @@ import { FormikDatePicker, FormikNumberInput, customDayjs, getLocalizedDayjs, us
 import { ReportingStatusEnum, type Reporting, getReportingStatus } from 'domain/entities/reporting'
 import { ReportingContext } from 'domain/shared_slices/Global'
 import { useFormikContext } from 'formik'
-import { forwardRef, useMemo } from 'react'
+import { useMemo } from 'react'
 import styled from 'styled-components'
 
 type ValidityProps = {
@@ -11,7 +11,7 @@ type ValidityProps = {
   reportingContext: ReportingContext
 }
 
-export const Validity = forwardRef<HTMLDivElement, ValidityProps>(({ mustIncreaseValidity, reportingContext }, ref) => {
+export function Validity({ mustIncreaseValidity, reportingContext }: ValidityProps) {
   const { newWindowContainerRef } = useNewWindow()
 
   const { values } = useFormikContext<Reporting>()
@@ -35,7 +35,7 @@ export const Validity = forwardRef<HTMLDivElement, ValidityProps>(({ mustIncreas
   )
 
   return (
-    <StyledValidityContainer ref={ref}>
+    <StyledValidityContainer>
       <div>
         <FormikDatePicker
           baseContainer={reportingContext === ReportingContext.SIDE_WINDOW ? newWindowContainerRef.current : undefined}
@@ -73,7 +73,7 @@ export const Validity = forwardRef<HTMLDivElement, ValidityProps>(({ mustIncreas
       )}
     </StyledValidityContainer>
   )
-})
+}
 
 const StyledFormikNumberInput = styled(FormikNumberInput)`
   max-width: 80px;

--- a/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/FormComponents/Validity.tsx
@@ -3,14 +3,15 @@ import { FormikDatePicker, FormikNumberInput, customDayjs, getLocalizedDayjs, us
 import { ReportingStatusEnum, type Reporting, getReportingStatus } from 'domain/entities/reporting'
 import { ReportingContext } from 'domain/shared_slices/Global'
 import { useFormikContext } from 'formik'
-import { useMemo } from 'react'
+import { forwardRef, useMemo } from 'react'
 import styled from 'styled-components'
 
 type ValidityProps = {
   mustIncreaseValidity: boolean
   reportingContext: ReportingContext
 }
-export function Validity({ mustIncreaseValidity, reportingContext }: ValidityProps) {
+
+export const Validity = forwardRef<HTMLDivElement, ValidityProps>(({ mustIncreaseValidity, reportingContext }, ref) => {
   const { newWindowContainerRef } = useNewWindow()
 
   const { values } = useFormikContext<Reporting>()
@@ -34,7 +35,7 @@ export function Validity({ mustIncreaseValidity, reportingContext }: ValidityPro
   )
 
   return (
-    <StyledValidityContainer>
+    <StyledValidityContainer ref={ref}>
       <div>
         <FormikDatePicker
           baseContainer={reportingContext === ReportingContext.SIDE_WINDOW ? newWindowContainerRef.current : undefined}
@@ -72,7 +73,7 @@ export function Validity({ mustIncreaseValidity, reportingContext }: ValidityPro
       )}
     </StyledValidityContainer>
   )
-}
+})
 
 const StyledFormikNumberInput = styled(FormikNumberInput)`
   max-width: 80px;

--- a/frontend/src/features/Reportings/components/ReportingForm/FormContent.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/FormContent.tsx
@@ -85,6 +85,8 @@ type FormContentProps = {
 export function FormContent({ reducedReportingsOnContext, selectedReporting }: FormContentProps) {
   const dispatch = useAppDispatch()
 
+  const openByRef = useRef<HTMLDivElement>(null)
+
   const scrollRef = useRef<HTMLDivElement>(null)
   const [scrollTop, setScrollTop] = useState(0)
   const { scrollPosition, setScrollPosition } = useReportingEventContext()
@@ -368,8 +370,9 @@ export function FormContent({ reducedReportingsOnContext, selectedReporting }: F
 
         <Validity mustIncreaseValidity={mustIncreaseValidity} reportingContext={reportingContext} />
 
-        <StyledFormikTextInput isErrorMessageHidden isRequired label="Saisi par" maxLength={3} name="openBy" />
-
+        <div ref={openByRef}>
+          <StyledFormikTextInput isErrorMessageHidden isRequired label="Saisi par" maxLength={3} name="openBy" />
+        </div>
         <Separator />
         <FormikTextarea label="Actions effectuées" name="actionTaken" />
 
@@ -404,7 +407,10 @@ export function FormContent({ reducedReportingsOnContext, selectedReporting }: F
         onClose={closeReporting}
         onDelete={deleteCurrentReporting}
         onSave={saveAndQuit}
-        setMustIncreaseValidity={setMustIncreaseValidity}
+        setMustIncreaseValidity={value => {
+          setMustIncreaseValidity(value)
+          openByRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+        }}
       />
     </StyledFormContainer>
   )

--- a/frontend/src/features/Reportings/components/ReportingForm/FormContent.tsx
+++ b/frontend/src/features/Reportings/components/ReportingForm/FormContent.tsx
@@ -407,9 +407,11 @@ export function FormContent({ reducedReportingsOnContext, selectedReporting }: F
         onClose={closeReporting}
         onDelete={deleteCurrentReporting}
         onSave={saveAndQuit}
-        setMustIncreaseValidity={value => {
-          setMustIncreaseValidity(value)
-          openByRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+        setMustIncreaseValidity={hasValidityError => {
+          setMustIncreaseValidity(hasValidityError)
+          if (hasValidityError) {
+            openByRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+          }
         }}
       />
     </StyledFormContainer>

--- a/frontend/src/features/commonComponents/Modals/MapInteraction.tsx
+++ b/frontend/src/features/commonComponents/Modals/MapInteraction.tsx
@@ -28,7 +28,7 @@ export function MapInteraction({
       <Panel>
         <Header>
           <Title>{title}</Title>
-          <IconButton Icon={Icon.Close} onClick={onCancel} />
+          <StyledIconButton Icon={Icon.Close} onClick={onCancel} />
         </Header>
 
         <Body>
@@ -75,6 +75,19 @@ const Title = styled.h1`
   font-size: 16px;
   font-weight: normal;
   line-height: 22px;
+`
+const StyledIconButton = styled(IconButton)`
+  &:hover,
+  &._hover {
+    background-color: ${p => p.theme.color.charcoal};
+    border: none;
+  }
+
+  &:active,
+  &._active {
+    background-color: ${p => p.theme.color.charcoal};
+    border: none;
+  }
 `
 
 const ButtonGroup = styled.div`

--- a/frontend/src/features/missions/MissionForm/ActionsTimeLine/ActionCard/EnvActions/index.tsx
+++ b/frontend/src/features/missions/MissionForm/ActionsTimeLine/ActionCard/EnvActions/index.tsx
@@ -47,7 +47,12 @@ export function EnvActions({
         <ReportingHistory action={action} />
       ) : (
         <Card>
-          <ActionSummaryWrapper $hasError={hasError} $selected={selected} $type={action.actionType}>
+          <ActionSummaryWrapper
+            $hasError={hasError}
+            $reportingType={action.actionType === ActionTypeEnum.REPORTING ? action.reportType : undefined}
+            $selected={selected}
+            $type={action.actionType}
+          >
             <ContentContainer>
               {action.actionType === ActionTypeEnum.CONTROL && <ControlCard action={action} />}
               {action.actionType === ActionTypeEnum.SURVEILLANCE && <SurveillanceCard action={action} />}

--- a/frontend/src/features/missions/MissionForm/ActionsTimeLine/ActionCard/style.ts
+++ b/frontend/src/features/missions/MissionForm/ActionsTimeLine/ActionCard/style.ts
@@ -1,4 +1,5 @@
 import { Icon, Tag } from '@mtes-mct/monitor-ui'
+import { ReportingTypeEnum } from 'domain/entities/reporting'
 import styled from 'styled-components'
 
 import { ActionTypeEnum } from '../../../../../domain/entities/missions'
@@ -27,7 +28,12 @@ export const TimeLine = styled.div<{ $isFishAction: boolean }>`
   ${p => p.$isFishAction && `padding-bottom: 20px;`}
 `
 
-export const ActionSummaryWrapper = styled.div<{ $hasError?: boolean; $selected?: boolean; $type?: string }>`
+export const ActionSummaryWrapper = styled.div<{
+  $hasError?: boolean
+  $reportingType?: ReportingTypeEnum
+  $selected?: boolean
+  $type?: string
+}>`
   display: flex;
   justify-content: space-between;
   flex-direction: column;
@@ -43,6 +49,9 @@ export const ActionSummaryWrapper = styled.div<{ $hasError?: boolean; $selected?
   border-style: solid;
   padding: 16px;
   background: ${p => {
+    if (p.$reportingType && p.$reportingType === ReportingTypeEnum.OBSERVATION) {
+      return p.theme.color.blueGray25
+    }
     switch (p.$type) {
       case ActionTypeEnum.CONTROL:
         return p.theme.color.white

--- a/frontend/src/features/missions/MissionForm/AttachReporting/AttachReportingToMissionModal.tsx
+++ b/frontend/src/features/missions/MissionForm/AttachReporting/AttachReportingToMissionModal.tsx
@@ -34,6 +34,11 @@ export function AttachReportingToMissionModal() {
     dispatch(updateMapInteractionListeners(MapInteractionListenerEnum.NONE))
   }
 
+  const cancelReportingToAttach = () => {
+    dispatch(attachReportingToMissionSliceActions.setAttachedReportings(initialAttachedReportings))
+    dispatch(updateMapInteractionListeners(MapInteractionListenerEnum.NONE))
+  }
+
   // Close modal when selected mission form is hidden
   useEffect(() => {
     if (previousMissionId && previousMissionId !== routeParams?.params?.id && isReportingAttachmentInProgress) {
@@ -47,6 +52,7 @@ export function AttachReportingToMissionModal() {
 
   return (
     <MapInteraction
+      onCancel={cancelReportingToAttach}
       onReset={resetReportingToAttach}
       onValidate={validateReportingToAttach}
       title="Vous êtes en train de lier un signalement"

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -3,7 +3,7 @@ import { setupListeners } from '@reduxjs/toolkit/query'
 import { FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE } from 'redux-persist'
 
 import { homeReducers } from './reducers'
-import { monitorenvPrivateApi, monitorenvPublicApi, geoserverApi } from '../api/api'
+import { monitorenvPrivateApi, monitorenvPublicApi } from '../api/api'
 
 const homeStore = configureStore({
   middleware: getDefaultMiddleware =>
@@ -15,7 +15,7 @@ const homeStore = configureStore({
         // TODO Replace all Redux state Dates by strings & Error by a strict-typed POJO.
         isSerializable: (value: any) => isPlain(value) || value instanceof Date || value instanceof Error
       }
-    }).concat(monitorenvPrivateApi.middleware, monitorenvPublicApi.middleware, geoserverApi.middleware),
+    }).concat(monitorenvPrivateApi.middleware, monitorenvPublicApi.middleware),
   reducer: combineReducers(homeReducers) as unknown as typeof homeReducers
 })
 

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -7,7 +7,7 @@ import { reportingSliceReducer } from '@features/Reportings/slice'
 import { vigilanceAreaFiltersPersistedReducer } from '@features/VigilanceArea/components/VigilanceAreasList/Filters/slice'
 import { vigilanceAreaPersistedReducer } from '@features/VigilanceArea/slice'
 
-import { geoserverApi, monitorenvPrivateApi, monitorenvPublicApi } from '../api/api'
+import { monitorenvPrivateApi, monitorenvPublicApi } from '../api/api'
 import { administrativeSlicePersistedReducer } from '../domain/shared_slices/Administrative'
 import { ampSlicePersistedReducer } from '../domain/shared_slices/Amp'
 import { drawReducer } from '../domain/shared_slices/Draw'
@@ -35,7 +35,6 @@ import { stationReducer } from '../features/Station/slice'
 
 // TODO Maybe add a specifc store for the backoffice (to make it lighter)?
 export const homeReducers = {
-  [geoserverApi.reducerPath]: geoserverApi.reducer,
   [monitorenvPrivateApi.reducerPath]: monitorenvPrivateApi.reducer,
   [monitorenvPublicApi.reducerPath]: monitorenvPublicApi.reducer,
   administrationTable: administrationTablePersistedReducer,


### PR DESCRIPTION
- Ajout de la fonction `onCancel` sur la pop-up de rattachement d'une mission à un signalement et la pop-up de rattachement d'un signalement à une mission.
- Lorsqu'on veut ré-ouvrir un signalement archivé, ajout d'un scroll vers le champ "Validité" pour signaler un souci au niveau des dates : 
![Capture d’écran 2024-11-26 à 18 06 17](https://github.com/user-attachments/assets/c4cb9438-3d4a-45ca-937a-641e325ee212)
- Mettre l'encart des signalements dans la timeline des missions en bleu si de type Observation
![Capture d’écran 2024-11-27 à 09 16 07](https://github.com/user-attachments/assets/1a57c918-d6af-4457-826d-965b59f957aa)

## Related Pull Requests & Issues

- Resolve #1767
- Resolve #1846 

----

- [ ] Tests E2E (Cypress)
