### PR TITLE
[Mission] Passer les valeurs reçues de `missionEvent` à `undefined` au lieu de `null`

### DIFF
--- a/frontend/src/features/Mission/components/MissionForm/slice.ts
+++ b/frontend/src/features/Mission/components/MissionForm/slice.ts
@@ -1,4 +1,4 @@
-import { type ControlUnit } from '@mtes-mct/monitor-ui'
+import { undefine, type ControlUnit } from '@mtes-mct/monitor-ui'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 import type { Infraction, Mission, NewInfraction, NewMission } from '../../../../domain/entities/missions'
@@ -144,7 +144,7 @@ const missionFormsSlice = createSlice({
           missionForm: {
             // We keep all data not received from the Mission event (see MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES)
             ...mission.missionForm,
-            ...action.payload
+            ...undefine(action.payload)
           } as Mission
         }
       }

--- a/frontend/src/features/Mission/components/MissionForm/slice.ts
+++ b/frontend/src/features/Mission/components/MissionForm/slice.ts
@@ -1,4 +1,4 @@
-import { undefine, type ControlUnit } from '@mtes-mct/monitor-ui'
+import { type ControlUnit } from '@mtes-mct/monitor-ui'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 import type { Infraction, Mission, NewInfraction, NewMission } from '../../../../domain/entities/missions'
@@ -144,7 +144,7 @@ const missionFormsSlice = createSlice({
           missionForm: {
             // We keep all data not received from the Mission event (see MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES)
             ...mission.missionForm,
-            ...undefine(action.payload)
+            ...action.payload
           } as Mission
         }
       }

--- a/frontend/src/features/Mission/components/MissionForm/sse.ts
+++ b/frontend/src/features/Mission/components/MissionForm/sse.ts
@@ -1,9 +1,11 @@
+import { undefine } from '@mtes-mct/monitor-ui'
+
 import { isMissionAutoUpdateEnabled } from './utils'
 
 import type { Mission } from '../../../../domain/entities/missions'
 
 export const missionEventListener = (callback: (mission: Mission) => void) => (event: MessageEvent) => {
-  const mission = JSON.parse(event.data) as Mission
+  const mission = undefine(JSON.parse(event.data)) as Mission
 
   // eslint-disable-next-line no-console
   console.log(`SSE: received a mission update.`)

--- a/frontend/src/features/Reportings/components/ReportingForm/sse.ts
+++ b/frontend/src/features/Reportings/components/ReportingForm/sse.ts
@@ -1,9 +1,11 @@
+import { undefine } from '@mtes-mct/monitor-ui'
+
 import { isReportingAutoUpdateEnabled } from './utils'
 
 import type { Reporting } from 'domain/entities/reporting'
 
 export const reportingEventListener = (callback: (reporting: Reporting) => void) => (event: MessageEvent) => {
-  const reporting = JSON.parse(event.data) as Reporting
+  const reporting = undefine(JSON.parse(event.data)) as Reporting
 
   // eslint-disable-next-line no-console
   console.log(`SSE: received a reporting update.`)


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #2021


----

- [ ] Tests E2E (Cypress)
