### PR TITLE
[Zones Administratives] N'afficher qu'une seule fois le nom des départements

### DIFF
--- a/frontend/src/features/map/layers/styles/administrativeAndRegulatoryLayers.style.ts
+++ b/frontend/src/features/map/layers/styles/administrativeAndRegulatoryLayers.style.ts
@@ -114,7 +114,6 @@ export const getAdministrativeLayersStyle = (code: String) => {
               fill: new Fill({ color: THEME.color.gunMetal }),
               font: '16px Marianne',
               overflow: true,
-              repeat: 1,
               stroke: new Stroke({ color: getColorWithAlpha(THEME.color.white, 0.9), width: 2 }),
               text: `${feature.get(Layers.DEPARTMENTS.zoneFieldKey) ?? ''}`
             })

--- a/frontend/src/features/map/layers/styles/administrativeAndRegulatoryLayers.style.ts
+++ b/frontend/src/features/map/layers/styles/administrativeAndRegulatoryLayers.style.ts
@@ -96,20 +96,32 @@ export const getAdministrativeLayersStyle = (code: String) => {
           })
         })
     case Layers.DEPARTMENTS.code:
-      return feature =>
-        new Style({
-          stroke: new Stroke({
-            color: darkPeriwinkle,
-            width: 2
+      return feature => {
+        const geometry = feature.getGeometry()
+        const center = geometry.getExtent()
+        const point = new Point(getCenter(center))
+
+        return [
+          new Style({
+            stroke: new Stroke({
+              color: darkPeriwinkle,
+              width: 2
+            })
           }),
-          text: new Text({
-            fill: new Fill({ color: THEME.color.gunMetal }),
-            font: '16px Marianne',
-            overflow: true,
-            stroke: new Stroke({ color: getColorWithAlpha(THEME.color.white, 0.9), width: 2 }),
-            text: `${feature.get(Layers.DEPARTMENTS.zoneFieldKey) ? feature.get(Layers.DEPARTMENTS.zoneFieldKey) : ''}`
+          new Style({
+            geometry: point,
+            text: new Text({
+              fill: new Fill({ color: THEME.color.gunMetal }),
+              font: '16px Marianne',
+              overflow: true,
+              repeat: 1,
+              stroke: new Stroke({ color: getColorWithAlpha(THEME.color.white, 0.9), width: 2 }),
+              text: `${feature.get(Layers.DEPARTMENTS.zoneFieldKey) ?? ''}`
+            })
           })
-        })
+        ]
+      }
+
     case Layers.SALTWATER_LIMIT_AREAS.code:
     case Layers.TRANSVERSAL_SEA_LIMIT_AREAS.code:
       return () =>


### PR DESCRIPTION
Au zoom sur les départements qui comprennent plusieurs îles (Guadeloupe par exemple) le nom du département s'affichait au niveau de chaque île. J'ai mis le texte sur le centre de la géométrie

## Related Pull Requests & Issues

- Resolve #1941

----

- [ ] Tests E2E (Cypress)
