### PR TITLE
Mise à jour de la vue `reporting_actions` et `analytics_actions`

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.169__update_reporting_actions_view.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.169__update_reporting_actions_view.sql
@@ -1,0 +1,64 @@
+DROP VIEW public.reporting_actions;
+
+CREATE VIEW public.reporting_actions AS
+
+SELECT 
+    r.id,
+    TEXT(reporting_id) AS reporting_id,
+    TO_TIMESTAMP(cast(created_at as TEXT),'YYYY-MM-DD-HH24:MI') AS signal_datetime_utc,
+    TEXT(source_type) AS source_type,
+    CASE
+        WHEN source_type = 'SEMAPHORE' THEN semaphores.unite
+        WHEN source_type = 'CONTROL_UNIT' THEN control_units.name
+        ELSE TEXT(source_name)
+    END AS origin_signal,
+    TEXT(sea_front) AS signal_facade,
+    CASE
+        WHEN r.theme IS NOT NULL THEN TEXT(r.theme)
+        ELSE control_plan_themes.theme
+    END AS theme_level_1,
+    TEXT(report_type) AS report_type,
+    CASE
+        WHEN vehicle_type IS NULL THEN TEXT(target_type)
+        ELSE TEXT(vehicle_type)
+    END AS target_type,
+    REPLACE(details->>'mmsi',' ','') AS mmsi,
+    details->>'vesselName' AS nom_navireSociete,
+    details->>'size' AS size,
+    details->>'imo' AS imo,
+    details->>'externalReferenceNumber' AS immatriculation,
+    details->>'operatorName' AS nom_propre,
+    CASE
+        WHEN with_vhf_answer = 'false' THEN TEXT('NON')
+        WHEN with_vhf_answer = 'true' THEN TEXT('OUI')
+        ELSE NULL
+    END AS reponse_vhf,
+    is_infraction_proven,
+    CASE
+        WHEN is_control_required = 'false' THEN TEXT('NON')
+        WHEN is_control_required = 'true' THEN TEXT('OUI')
+        ELSE NULL
+    END AS control_required,
+    CASE
+        WHEN has_no_unit_available = 'false' THEN TEXT('DISPONIBLE')
+        WHEN has_no_unit_available = 'true' THEN TEXT('NON DISPONIBLE')
+        WHEN has_no_unit_available IS NULL AND r.mission_id IS NOT NULL THEN TEXT('DISPONIBLE')
+        ELSE NULL
+    END AS control_unit_dispo,
+    CASE
+        WHEN detached_from_mission_at_utc IS NULL THEN r.mission_id
+        ELSE NULL
+    END AS mission_id,
+    r.attached_env_action_id AS action_id,
+    r.geom,
+    TEXT(description) AS description,
+    TEXT(action_taken) AS action_taken,
+    TEXT(open_by) AS open_by
+FROM reportings r
+JOIN reportings_source ON r.id = reportings_source.reportings_id
+LEFT JOIN semaphores ON reportings_source.semaphore_id = semaphores.id
+LEFT JOIN control_units ON reportings_source.control_unit_id = control_units.id
+LEFT JOIN control_plan_themes ON r.control_plan_theme_id = control_plan_themes.id
+    LEFT JOIN LATERAL jsonb_array_elements(target_details) AS details ON TRUE
+WHERE is_deleted = 'false'
+ORDER BY id DESC;

--- a/backend/src/main/resources/db/migration/internal/V0.170__exclude_actions_without_unit_from_analytic_actions.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.170__exclude_actions_without_unit_from_analytic_actions.sql
@@ -1,0 +1,76 @@
+/* Update analytics_actions views */
+DROP MATERIALIZED VIEW analytics_actions;
+
+CREATE MATERIALIZED VIEW public.analytics_actions AS
+
+SELECT
+    a.id,
+    a.mission_id,
+    action_start_datetime_utc,
+    action_end_datetime_utc,
+    EXTRACT(year FROM action_start_datetime_utc) AS year,
+    m.start_datetime_utc AS mission_start_datetime_utc,
+    m.end_datetime_utc AS mission_end_datetime_utc,
+    mission_type,
+    action_type,
+    COALESCE(m.facade, 'Hors façade') AS mission_facade,
+    cu.id AS control_unit_id,
+    cu.name AS control_unit,
+    adm.name AS administration,
+    cu.name ILIKE 'ulam%' OR (
+        adm.name = 'DIRM / DM' AND
+        cu.name ILIKE 'PAM%'
+    ) AS is_aff_mar,
+    (
+        cu.name ILIKE 'ulam%' OR (
+            adm.name = 'DIRM / DM' AND
+            cu.name ILIKE 'PAM%'
+        )
+    ) OR adm.name IN ('Gendarmerie Nationale', 'Gendarmerie Maritime', 'Douane', 'Marine Nationale') AS is_aem,
+    CASE
+        WHEN cu.name ILIKE 'ulam%' OR (adm.name = 'DIRM / DM' AND cu.name ILIKE 'PAM%') THEN 'Affaires Maritimes'
+        WHEN adm.name IN ('Gendarmerie Nationale', 'Gendarmerie Maritime', 'Douane', 'Marine Nationale') THEN adm.name
+        ELSE 'Administrations hors AEM'
+    END AS administration_aem,
+    COALESCE(a.facade, 'Hors façade') AS action_facade,
+    COALESCE(a.department, 'Hors département') AS action_department,
+    CASE COALESCE(t3.theme, 'Aucun thème')
+        WHEN 'Activités et manifestations soumises à évaluation d’incidence Natura 2000' THEN 'EIN2000'
+        ELSE COALESCE(t3.theme, 'Aucun thème')
+    END AS theme_level_1,
+    COALESCE(t2.subtheme, 'Aucun sous-thème') AS theme_level_2,
+    CASE
+        WHEN t3.theme LIKE '%êche%' THEN 'PIRC'
+        ELSE 'PSCEM'
+    END AS plan,
+    CASE WHEN action_type = 'CONTROL' THEN ST_X(geom_element.geom) END AS longitude,
+    CASE WHEN action_type = 'CONTROL' THEN ST_Y(geom_element.geom) END AS latitude,
+    CASE WHEN action_type = 'CONTROL' THEN CASE WHEN jsonb_array_length(a.value->'infractions') > 0 THEN true ELSE false END END AS infraction,
+    (a.value->>'actionNumberOfControls')::DOUBLE PRECISION AS number_of_controls,
+    CASE WHEN action_type = 'SURVEILLANCE' THEN EXTRACT(epoch FROM a.action_end_datetime_utc - a.action_start_datetime_utc) / 3600.0 END AS surveillance_duration,
+    m.observations_cacem
+FROM env_actions a
+LEFT JOIN ST_Dump(a.geom) AS geom_element
+ON true
+LEFT JOIN env_actions_control_plan_themes t0 on t0.env_action_id = a.id
+LEFT JOIN env_actions_control_plan_sub_themes t1 on t1.env_action_id = a.id
+LEFT JOIN control_plan_sub_themes t2 on t2.id = t1.subtheme_id
+LEFT JOIN control_plan_themes t3 on t3.id = t0.theme_id
+JOIN missions m
+ON a.mission_id = m.id
+LEFT JOIN LATERAL unnest(mission_types) mission_type ON true
+LEFT JOIN missions_control_units mcu
+ON mcu.mission_id = m.id
+LEFT JOIN control_units cu
+ON cu.id = mcu.control_unit_id
+LEFT JOIN administrations adm
+ON adm.id = cu.administration_id
+WHERE
+    NOT m.deleted AND
+    completion = 'COMPLETED' AND
+    action_type IN ('CONTROL', 'SURVEILLANCE') AND
+    (t2.id IS NULL OR t3.id IS NULL OR t2.theme_id = t3.id) AND
+    cu.id IS NOT NULL
+ORDER BY action_start_datetime_utc DESC;
+
+CREATE INDEX ON analytics_actions USING BRIN(action_start_datetime_utc);


### PR DESCRIPTION
Demande Morgan concernant la vue `reporting_actions`.
Pour la vue `analytics_actions`, j'exclus les actions sans unité associée (15 contrôles de Poséidon en 2021/2022).