### PR TITLE
Désactiver les builds automatiques d'images de base de données

### DIFF
--- a/.github/workflows/cicd-database.yml
+++ b/.github/workflows/cicd-database.yml
@@ -1,10 +1,7 @@
 name: CI/CD database docker image
 
 on:
-  push:
-    paths:
-      - ".github/workflows/cicd-database.yml"
-      - "infra/docker/database/*"
+  workflow_dispatch:
 
 jobs:
   build-legacy-database-image:


### PR DESCRIPTION
Car 1/ pas nécessaire et 2/ cause de bugs car la CI tourne à chaque release