### PR TITLE
[Tableau de bord & brief] Résolution du bug sur le filtre par thématique dans la vue liste

### DIFF
--- a/frontend/src/features/Dashboard/components/DashboardsList/Filters.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardsList/Filters.tsx
@@ -125,7 +125,7 @@ export function Filters({ orientation = 'row' }: { orientation?: Orientation }) 
           key={regulatoryTheme}
           onDelete={() => onDeleteTag(regulatoryTheme, 'regulatoryThemes', regulatoryThemes)}
         >
-          {String(`Thématique réglementaire ${getTitle(regulatoryTheme)}`)}
+          {String(`Thématique ${getTitle(regulatoryTheme)}`)}
         </SingleTag>
       ))}
     </>

--- a/frontend/src/features/Dashboard/components/DashboardsList/Filters.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardsList/Filters.tsx
@@ -125,7 +125,7 @@ export function Filters({ orientation = 'row' }: { orientation?: Orientation }) 
           key={regulatoryTheme}
           onDelete={() => onDeleteTag(regulatoryTheme, 'regulatoryThemes', regulatoryThemes)}
         >
-          {String(`Thématique ${getTitle(regulatoryTheme)}`)}
+          {String(`${orientation === 'row' ? 'Thématique ' : ''}${getTitle(regulatoryTheme)}`)}
         </SingleTag>
       ))}
     </>

--- a/frontend/src/features/Dashboard/components/DashboardsList/Rows/RegulatoryAreasThemesCell.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardsList/Rows/RegulatoryAreasThemesCell.tsx
@@ -11,9 +11,11 @@ export function RegulatoryAreasThemesCell({ themeIds }: { themeIds: number[] }) 
     return '-'
   }
 
-  const regulatoryAreasThemes = uniq(themeIds.map(themeId => regulatoryAreas.entities[themeId]?.thematique))
-    .filter(Boolean)
-    .join(', ')
+  const uniqueThemes = uniq(
+    themeIds.map(themeId => regulatoryAreas.entities[themeId]?.thematique.split(', ')).flatMap(theme => theme)
+  )
+
+  const regulatoryAreasThemes = uniqueThemes.filter(Boolean).join(', ')
 
   return <span title={regulatoryAreasThemes}>{regulatoryAreasThemes}</span>
 }

--- a/frontend/src/features/Dashboard/useCases/filters/filterByRegulatoryThemes.ts
+++ b/frontend/src/features/Dashboard/useCases/filters/filterByRegulatoryThemes.ts
@@ -1,18 +1,23 @@
+import { uniq } from 'lodash'
+
 import type { Dashboard } from '@features/Dashboard/types'
 import type { RegulatoryLayerWithMetadata } from 'domain/entities/regulatory'
 
 export function filterByRegulatoryThemes(
-  regulatoryThemes: string[],
+  regulatoryThemesFilter: string[],
   dashboard: Dashboard.DashboardFromApi,
   regulatoryAreas: RegulatoryLayerWithMetadata[]
 ): boolean {
-  if (regulatoryThemes.length === 0) {
+  if (regulatoryThemesFilter.length === 0) {
     return true
   }
 
   const filteredRegulatoryAreas = regulatoryAreas.filter(regulatoryArea =>
     dashboard.regulatoryAreaIds?.includes(regulatoryArea.id)
   )
+  const uniqueThemes = uniq(
+    filteredRegulatoryAreas.map(regulatoryArea => regulatoryArea?.thematique.split(', ')).flatMap(theme => theme)
+  )
 
-  return filteredRegulatoryAreas.some(reg => regulatoryThemes.includes(reg.thematique))
+  return uniqueThemes.some(reg => regulatoryThemesFilter.includes(reg))
 }

--- a/frontend/src/features/Mission/components/Filters/Map/index.tsx
+++ b/frontend/src/features/Mission/components/Filters/Map/index.tsx
@@ -269,7 +269,7 @@ export const MapMissionFilters = forwardRef<HTMLDivElement, MapMissionFiltersPro
                 key={theme}
                 onDelete={() => onDeleteTag(theme, MissionFiltersEnum.THEME_FILTER, selectedThemes)}
               >
-                {`Thème ${themesAsOptions.find(t => t.value === theme)?.label ?? theme}`}
+                {`${themesAsOptions.find(t => t.value === theme)?.label ?? theme}`}
               </SingleTag>
             ))}
         </StyledBloc>


### PR DESCRIPTION
Il y avait un souci parce que les thématiques dans les zones reg sont des tableaux de string.

J'ai également supprimé les mot `thème` des tags de filtres côté carto (ticket 2093)
## Related Pull Requests & Issues

- Resolve #1928 
- Resolve #2093 


----

- [ ] Tests E2E (Cypress)
