### PR TITLE
[Tech] Permettre de patch missionTypes sur MissionEntity

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/MissionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/MissionEntity.kt
@@ -8,6 +8,7 @@ import java.time.ZonedDateTime
 
 data class MissionEntity(
     val id: Int? = null,
+    @Patchable
     val missionTypes: List<MissionTypeEnum>,
     val controlUnits: List<LegacyControlUnitEntity> = listOf(),
     val openBy: String? = null,

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/PatchableMissionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/domain/entities/mission/PatchableMissionEntity.kt
@@ -7,4 +7,5 @@ data class PatchableMissionEntity(
     val observationsByUnit: Optional<String>?,
     val startDateTimeUtc: ZonedDateTime?,
     val endDateTimeUtc: Optional<ZonedDateTime>?,
+    val missionTypes: List<MissionTypeEnum>?,
 )

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/PatchableMissionDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/inputs/PatchableMissionDataInput.kt
@@ -1,6 +1,7 @@
 package fr.gouv.cacem.monitorenv.infrastructure.api.adapters.publicapi.inputs
 
 import fr.gouv.cacem.monitorenv.domain.entities.mission.PatchableMissionEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionTypeEnum
 import java.time.ZonedDateTime
 import java.util.Optional
 
@@ -8,12 +9,14 @@ data class PatchableMissionDataInput(
     val observationsByUnit: Optional<String>?,
     val startDateTimeUtc: ZonedDateTime?,
     val endDateTimeUtc: Optional<ZonedDateTime>?,
+    val missionTypes:  List<MissionTypeEnum>?,
 ) {
     fun toPatchableMissionEntity(): PatchableMissionEntity {
         return PatchableMissionEntity(
             observationsByUnit = observationsByUnit,
             startDateTimeUtc = startDateTimeUtc,
             endDateTimeUtc = endDateTimeUtc,
+            missionTypes = missionTypes
         )
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMissionUTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/domain/use_cases/missions/PatchMissionUTest.kt
@@ -9,6 +9,7 @@ import fr.gouv.cacem.monitorenv.domain.mappers.PatchEntity
 import fr.gouv.cacem.monitorenv.domain.repositories.IMissionRepository
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.dtos.MissionDetailsDTO
 import fr.gouv.cacem.monitorenv.domain.use_cases.missions.fixtures.MissionFixture.Companion.aMissionEntity
+import fr.gouv.cacem.monitorenv.domain.entities.mission.MissionTypeEnum
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -38,6 +39,7 @@ class PatchMissionUTest {
                 observationsByUnit = Optional.of(patchedObservationsByUnit),
                 startDateTimeUtc = today,
                 endDateTimeUtc = Optional.of(tomorrow),
+                missionTypes = listOf(MissionTypeEnum.LAND)
             )
         val missionFromDatabase = aMissionEntity(id = id)
         val missionPatched =
@@ -46,6 +48,7 @@ class PatchMissionUTest {
                 observationsByUnit = patchedObservationsByUnit,
                 startDateTimeUtc = today,
                 endDateTimeUtc = tomorrow,
+                missionTypes = listOf(MissionTypeEnum.SEA)
             )
 
         given(missionRepository.findById(id)).willReturn(missionFromDatabase)
@@ -58,6 +61,7 @@ class PatchMissionUTest {
         assertThat(savedMission.mission.observationsByUnit).isEqualTo(missionPatched.observationsByUnit)
         assertThat(savedMission.mission.startDateTimeUtc).isEqualTo(missionPatched.startDateTimeUtc)
         assertThat(savedMission.mission.endDateTimeUtc).isEqualTo(missionPatched.endDateTimeUtc)
+        assertThat(savedMission.mission.missionTypes).isEqualTo(missionPatched.missionTypes)
         verify(missionRepository).save(missionPatched)
         assertThat(log.out).contains("Attempt to PATCH mission $id")
         assertThat(log.out).contains("Mission $id patched")
@@ -72,6 +76,7 @@ class PatchMissionUTest {
                 observationsByUnit = null,
                 startDateTimeUtc = null,
                 endDateTimeUtc = null,
+                missionTypes = null
             )
 
         given(missionRepository.findById(id)).willReturn(null)


### PR DESCRIPTION
## Description

RapportNav aura besoin de modifier le `missionTypes` de la Mission, je l'ai donc rajouté en Patchable.

Dîtes moi si j'ai oublié qqch, merci.

----

- [ ] Tests E2E (Cypress)
