### PR TITLE
[Mission] Vider le champ Type de véhicule lors de la mise à jour du champ Type de cible

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/mission_actions.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/mission_actions.spec.ts
@@ -682,6 +682,15 @@ context('Side Window > Mission Form > Mission actions', () => {
       cy.wait(500)
 
       cy.fill('Nb total de contrôles', 1)
+
+      cy.fill('Type de cible', 'Véhicule')
+      cy.fill('Type de véhicule', 'Autre véhicule marin')
+
+      // update target type and check if vehicle type is cleaned
+      cy.fill('Type de cible', 'Personne morale')
+      cy.get('[id="envActions.0.vehicleType"]').should('have.value', '')
+
+      // re add vehicle type
       cy.fill('Type de cible', 'Véhicule')
       cy.fill('Type de véhicule', 'Navire')
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/ControlForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/ControlForm/index.tsx
@@ -167,12 +167,12 @@ export function ControlForm({
     }
 
     setFieldValue(`envActions[${envActionIndex}].actionTargetType`, selectedTargetType)
+    setFieldValue(`envActions[${envActionIndex}].vehicleType`, undefined)
     if (
       selectedTargetType !== TargetTypeEnum.VEHICLE &&
       currentAction?.infractions &&
       currentAction?.infractions?.length > 0
     ) {
-      setFieldValue(`envActions[${envActionIndex}].vehicleType`, undefined)
       setFieldValue(
         `envActions[${envActionIndex}].infractions`,
         currentAction.infractions?.map(infraction => omit(infraction, ['vesselSize', 'vesselType']))


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #2157 

----

- [ ] Tests E2E (Cypress)
