### PR TITLE
[RecentActivity] Le filtre de distinction doit être inactif si un seul statut "Avec/Sans infraction" est coché

### DIFF
--- a/frontend/src/features/RecentActivity/components/RecentActivityMenuButton/DistinctionFilters.tsx
+++ b/frontend/src/features/RecentActivity/components/RecentActivityMenuButton/DistinctionFilters.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 export function DistinctionFilters() {
   const dispatch = useAppDispatch()
+  const infractionFilters = useAppSelector(state => state.recentActivity.filters.infractionsStatus)
   const distinctionFilter = useAppSelector(state => state.recentActivity.distinctionFilter)
   const controlUnitsWithInfraction = useAppSelector(
     state => state.recentActivity.distinctionFiltersItems.infractions.withInfraction
@@ -26,6 +27,7 @@ export function DistinctionFilters() {
   return (
     <Wrapper>
       <Select
+        disabled={!!(infractionFilters?.length === 1)}
         isCleanable={false}
         isLabelHidden
         isTransparent

--- a/frontend/src/features/RecentActivity/components/RecentActivityMenuButton/RecentActivityFilters.tsx
+++ b/frontend/src/features/RecentActivity/components/RecentActivityMenuButton/RecentActivityFilters.tsx
@@ -83,19 +83,18 @@ export function RecentActivityFilters() {
 
   const updateCheckboxFilter = (isChecked: boolean | undefined, value: string) => {
     const updatedFilter = [...(filters.infractionsStatus ?? [])]
-
+    let newFilter
     if (!isChecked && updatedFilter.includes(String(value))) {
-      const newFilter = updatedFilter.filter(status => status !== String(value))
-      dispatch(
-        recentActivityActions.updateFilters({ key: RecentActivityFiltersEnum.INFRACTIONS_STATUS, value: newFilter })
-      )
+      newFilter = updatedFilter.filter(status => status !== String(value))
     }
     if (isChecked && !updatedFilter.includes(value)) {
-      const newFilter = [...updatedFilter, value]
-
-      dispatch(
-        recentActivityActions.updateFilters({ key: RecentActivityFiltersEnum.INFRACTIONS_STATUS, value: newFilter })
-      )
+      newFilter = [...updatedFilter, value]
+    }
+    dispatch(
+      recentActivityActions.updateFilters({ key: RecentActivityFiltersEnum.INFRACTIONS_STATUS, value: newFilter })
+    )
+    if (newFilter.length === 1) {
+      dispatch(recentActivityActions.updateDistinctionFilter(RecentActivity.DistinctionFilterEnum.WITHOUT_DISTINCTION))
     }
   }
 


### PR DESCRIPTION

----

- [ ] Tests E2E (Cypress)
