### PR TITLE
[Tableau de Bord] Ré-afficher les couches quand on désactive le focus depuis la bannière

### DIFF
--- a/frontend/src/features/Dashboard/components/MapFocusForDashboardBanner.tsx
+++ b/frontend/src/features/Dashboard/components/MapFocusForDashboardBanner.tsx
@@ -1,5 +1,6 @@
 import { useAppDispatch } from '@hooks/useAppDispatch'
 import { LinkButton } from '@mtes-mct/monitor-ui'
+import { resetState } from 'domain/shared_slices/Global'
 import styled from 'styled-components'
 
 import { dashboardActions } from '../slice'
@@ -8,6 +9,7 @@ export function MapFocusForDashboardBanner() {
   const dispatch = useAppDispatch()
   const disableDashboardMapFocus = () => {
     dispatch(dashboardActions.setMapFocus(false))
+    dispatch(resetState())
   }
 
   return (


### PR DESCRIPTION
Je ne remettais pas l'état initial des layers sur la carto au clique sur la désactivation du focus

## Related Pull Requests & Issues

- Resolve #2189


----

- [ ] Tests E2E (Cypress)
