### PR TITLE
[Thématiques et tag] Cacher les sous-thématiques et sous-tags dans les résumés des zones de vigilances et des zones réglementaires

### DIFF
--- a/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/Panel/PanelPeriodAndThemes.tsx
+++ b/frontend/src/features/VigilanceArea/components/VigilanceAreaForm/Panel/PanelPeriodAndThemes.tsx
@@ -23,6 +23,9 @@ export function PanelPeriodAndThemes({ vigilanceArea }: { vigilanceArea: Vigilan
     ? customDayjs(vigilanceArea?.endDatePeriod).utc().format('DD/MM/YYYY')
     : undefined
 
+  const subThemes = displaySubThemes(vigilanceArea?.themes)
+  const subTags = displaySubTags(vigilanceArea?.tags)
+
   return (
     <>
       <PanelSubPart>
@@ -60,26 +63,29 @@ export function PanelPeriodAndThemes({ vigilanceArea }: { vigilanceArea: Vigilan
               : EMPTY_VALUE}
           </PanelInlineItemValue>
         </PanelInlineItem>
-        <PanelInlineItem>
-          <PanelInlineItemLabel $isInline>Sous-thématiques</PanelInlineItemLabel>
-          <PanelInlineItemValue $maxLine={2} title={displaySubThemes(vigilanceArea?.themes) ?? ''}>
-            {vigilanceArea?.themes && vigilanceArea?.themes.length > 0
-              ? displaySubThemes(vigilanceArea?.themes)
-              : EMPTY_VALUE}
-          </PanelInlineItemValue>
-        </PanelInlineItem>
+        {subThemes && (
+          <PanelInlineItem>
+            <PanelInlineItemLabel $isInline>Sous-thématiques</PanelInlineItemLabel>
+            <PanelInlineItemValue $maxLine={2} title={subThemes}>
+              {subThemes}
+            </PanelInlineItemValue>
+          </PanelInlineItem>
+        )}
         <PanelInlineItem>
           <PanelInlineItemLabel $isInline>Tags</PanelInlineItemLabel>
           <PanelInlineItemValue $maxLine={2} title={displayTags(vigilanceArea?.tags) ?? ''}>
             {vigilanceArea?.tags && vigilanceArea?.tags.length > 0 ? displayTags(vigilanceArea?.tags) : EMPTY_VALUE}
           </PanelInlineItemValue>
         </PanelInlineItem>
-        <PanelInlineItem>
-          <PanelInlineItemLabel $isInline>Sous-tags</PanelInlineItemLabel>
-          <PanelInlineItemValue $maxLine={2} title={displaySubTags(vigilanceArea?.tags) ?? ''}>
-            {vigilanceArea?.tags && vigilanceArea?.tags.length > 0 ? displaySubTags(vigilanceArea?.tags) : EMPTY_VALUE}
-          </PanelInlineItemValue>
-        </PanelInlineItem>
+        {subTags && (
+          <PanelInlineItem>
+            <PanelInlineItemLabel $isInline>Sous-tags</PanelInlineItemLabel>
+            <PanelInlineItemValue $maxLine={2} title={subTags}>
+              {subTags}
+            </PanelInlineItemValue>
+          </PanelInlineItem>
+        )}
+
         <PanelInlineItem>
           <PanelInlineItemLabel $isInline>Visibilité</PanelInlineItemLabel>
           <PanelInlineItemValue>

--- a/frontend/src/features/layersSelector/metadataPanel/regulatoryMetadata/Identification.tsx
+++ b/frontend/src/features/layersSelector/metadataPanel/regulatoryMetadata/Identification.tsx
@@ -1,3 +1,6 @@
+import { displaySubTags } from '@utils/getTagsAsOptions'
+import { displaySubThemes } from '@utils/getThemesAsOptions'
+
 import { Body, Field, Fields, Key, NoValue, Value, Zone } from '../MetadataPanel.style'
 
 import type { TagFromAPI } from 'domain/entities/tags'
@@ -16,6 +19,9 @@ export function Identification({
   themes: ThemeFromAPI[]
   type: string
 }) {
+  const subThemes = displaySubThemes(themes)
+  const subTags = displaySubTags(tags)
+
   return (
     <Zone>
       <Fields>
@@ -34,26 +40,24 @@ export function Identification({
               {themes.map(theme => theme.name).join(', ') || <NoValue>-</NoValue>}
             </Value>
           </Field>
-          <Field>
-            <Key>Sous-thématiques</Key>
-            <Value data-cy="regulatory-layers-metadata-subtheme">
-              {themes.flatMap(theme => theme.subThemes.map(subTheme => subTheme.name)).join(', ') || (
-                <NoValue>-</NoValue>
-              )}
-            </Value>
-          </Field>
+          {subThemes && (
+            <Field>
+              <Key>Sous-thématiques</Key>
+              <Value data-cy="regulatory-layers-metadata-subtheme">{subThemes}</Value>
+            </Field>
+          )}
           <Field>
             <Key>Tags</Key>
             <Value data-cy="regulatory-layers-metadata-tag">
               {tags.map(tag => tag.name).join(', ') || <NoValue>-</NoValue>}
             </Value>
           </Field>
-          <Field>
-            <Key>Sous-tags</Key>
-            <Value data-cy="regulatory-layers-metadata-subtag">
-              {tags.flatMap(tag => tag.subTags.map(subTag => subTag.name)).join(', ') || <NoValue>-</NoValue>}
-            </Value>
-          </Field>
+          {subTags && (
+            <Field>
+              <Key>Sous-tags</Key>
+              <Value data-cy="regulatory-layers-metadata-subtag">{subTags}</Value>
+            </Field>
+          )}
           <Field>
             <Key>Façade</Key>
             <Value data-cy="regulatory-layers-metadata-facade">{facade || <NoValue>-</NoValue>}</Value>


### PR DESCRIPTION
Uniquement si elles sont absentes.