### PR TITLE
[Unité de contrôle] Résolution du bug de cache sur l'ajout de moyen et de contact à une unité de contrôle

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaControlUnitContactRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaControlUnitContactRepository.kt
@@ -8,6 +8,7 @@ import fr.gouv.cacem.monitorenv.infrastructure.database.model.ControlUnitContact
 import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.interfaces.IDBControlUnitContactRepository
 import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.interfaces.IDBControlUnitRepository
 import fr.gouv.cacem.monitorenv.utils.requirePresent
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.dao.InvalidDataAccessApiUsageException
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
@@ -32,6 +33,7 @@ class JpaControlUnitContactRepository(
     override fun findById(controlUnitContactId: Int): FullControlUnitContactDTO =
         dbControlUnitContactRepository.findById(controlUnitContactId).get().toFullControlUnitContact()
 
+    @CacheEvict(value = ["control_units"], allEntries = true)
     @Transactional
     override fun save(controlUnitContact: ControlUnitContactEntity): ControlUnitContactEntity =
         try {

--- a/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaControlUnitResourceRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaControlUnitResourceRepository.kt
@@ -9,6 +9,7 @@ import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.interfaces.
 import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.interfaces.IDBControlUnitResourceRepository
 import fr.gouv.cacem.monitorenv.infrastructure.database.repositories.interfaces.IDBStationRepository
 import fr.gouv.cacem.monitorenv.utils.requirePresent
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.dao.InvalidDataAccessApiUsageException
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
@@ -41,6 +42,7 @@ class JpaControlUnitResourceRepository(
     override fun findById(controlUnitResourceId: Int): FullControlUnitResourceDTO =
         dbControlUnitResourceRepository.findById(controlUnitResourceId).get().toFullControlUnitResource()
 
+    @CacheEvict(value = ["control_units"], allEntries = true)
     @Transactional
     override fun save(controlUnitResource: ControlUnitResourceEntity): ControlUnitResourceEntity =
         try {


### PR DESCRIPTION
La liste des unités de contrôle ne se mettait pas à jour lors de l'ajout/modification de moyen ou de contact

----

- [ ] Tests E2E (Cypress)
