### PR TITLE
[Tableau de bord] Mise à jour du tag des zones de vigilance pour afficher "INTERNE" à la place de "CACEM"

### DIFF
--- a/frontend/cypress/e2e/side_window/dashboard/edit_dashboard.spec.ts
+++ b/frontend/cypress/e2e/side_window/dashboard/edit_dashboard.spec.ts
@@ -24,7 +24,7 @@ context('Side Window > Dashboard > Edit Dashboard', () => {
     cy.wait(250)
     cy.getDataCy('dashboard-vigilance-area-zone-tags-and-buttons-8')
       .find('.Element-Tag')
-      .contains('CACEM')
+      .contains('INTERNE')
       .should('exist')
     cy.getDataCy('dashboard-vigilance-area-zone-check-8').click({ force: true })
 

--- a/frontend/src/features/Dashboard/components/DashboardForm/VigilanceAreas/Layer.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardForm/VigilanceAreas/Layer.tsx
@@ -83,7 +83,7 @@ export function Layer({ isPinned = false, isSelected = false, vigilanceArea }: V
       <TagAndButtons data-cy={`dashboard-vigilance-area-zone-tags-and-buttons-${vigilanceArea.id}`}>
         {vigilanceArea.visibility === VigilanceArea.Visibility.PRIVATE && (
           <StyledTag accent={Accent.PRIMARY} title="Zone de vigilance interne au CACEM">
-            CACEM
+            INTERNE
           </StyledTag>
         )}
 


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve #2378 

----

- [X] Tests E2E (Cypress)
