### PR TITLE
[Mission] Résolution du bug avec les événements de mise à jour automatique d'une mission

### DIFF
--- a/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaControlUnitRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cacem/monitorenv/infrastructure/database/repositories/JpaControlUnitRepositoryITests.kt
@@ -536,7 +536,7 @@ class JpaControlUnitRepositoryITests : AbstractDBTests() {
         val nearbyUnits = jpaControlUnitRepository.findNearbyUnits(geom, from, to)
 
         // Then
-        assertThat(nearbyUnits).hasSize(4)
+        assertThat(nearbyUnits).hasSize(3)
         nearbyUnits.forEach { nearbyUnit ->
             nearbyUnit.missions.forEach { mission ->
                 mission.envActions?.forEach { envAction ->

--- a/frontend/src/context/mission/MissionEventContext.tsx
+++ b/frontend/src/context/mission/MissionEventContext.tsx
@@ -4,21 +4,26 @@ import type { Mission } from 'domain/entities/missions'
 
 type MissionEventContextProps = {
   contextMissionEvent: Mission | undefined
+  event: string | undefined
   getMissionEventById: (missionId: number | string | undefined) => Mission | undefined
+  setEventType: (eventType: string | undefined) => void
   setMissionEventInContext: React.Dispatch<React.SetStateAction<Mission | undefined>>
 }
 export const MissionEventContext = createContext<MissionEventContextProps | undefined>(undefined)
 
 export function MissionEventProvider({ children }) {
   const [contextMissionEvent, setMissionEventInContext] = useState<Mission | undefined>(undefined)
+  const [event, setEventType] = useState<string | undefined>(undefined)
   const contextValue = useMemo(
     () => ({
       contextMissionEvent,
+      event,
       getMissionEventById: (missionId: number | string | undefined) =>
         missionId && contextMissionEvent?.id === missionId ? (contextMissionEvent as Mission | undefined) : undefined,
+      setEventType,
       setMissionEventInContext
     }),
-    [contextMissionEvent, setMissionEventInContext]
+    [contextMissionEvent, setMissionEventInContext, event, setEventType]
   )
 
   return <MissionEventContext.Provider value={contextValue}>{children}</MissionEventContext.Provider>

--- a/frontend/src/features/Mission/components/MissionForm/FormikSyncMissionFields.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/FormikSyncMissionFields.tsx
@@ -34,14 +34,16 @@ export function FormikSyncMissionFields({ missionId }: FormikSyncMissionFormProp
         return
       }
 
-      let receivedDiff = diff(
-        omit(values, MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM),
-        omit(missionEvent, MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM)
-      )
+      let receivedDiff
       if (event === FULL_MISSION_UPDATE_EVENT) {
         receivedDiff = diff(
           omit(values, FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM),
           omit(missionEvent, FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM)
+        )
+      } else {
+        receivedDiff = diff(
+          omit(values, MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM),
+          omit(missionEvent, MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM)
         )
       }
 

--- a/frontend/src/features/Mission/components/MissionForm/FormikSyncMissionFields.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/FormikSyncMissionFields.tsx
@@ -7,7 +7,11 @@ import { omit } from 'lodash'
 import { useEffect } from 'react'
 
 import { attachReportingToMissionSliceActions } from './AttachReporting/slice'
-import { MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM } from './constants'
+import {
+  FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM,
+  MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM
+} from './constants'
+import { FULL_MISSION_UPDATE_EVENT } from './hooks/useListenMissionEventUpdates'
 
 import type { Mission } from '../../../../domain/entities/missions'
 
@@ -21,7 +25,7 @@ export function FormikSyncMissionFields({ missionId }: FormikSyncMissionFormProp
   const dispatch = useAppDispatch()
 
   const { setFieldValue, values } = useFormikContext<Mission>()
-  const { getMissionEventById, setMissionEventInContext } = useMissionEventContext()
+  const { event, getMissionEventById, setMissionEventInContext } = useMissionEventContext()
   const missionEvent = getMissionEventById(missionId)
 
   useEffect(
@@ -30,10 +34,16 @@ export function FormikSyncMissionFields({ missionId }: FormikSyncMissionFormProp
         return
       }
 
-      const receivedDiff = diff(
+      let receivedDiff = diff(
         omit(values, MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM),
         omit(missionEvent, MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM)
       )
+      if (event === FULL_MISSION_UPDATE_EVENT) {
+        receivedDiff = diff(
+          omit(values, FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM),
+          omit(missionEvent, FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM)
+        )
+      }
 
       /**
        * We iterate and use `setFieldValue` on each diff key to avoid a global re-render of the <MissionForm/> component

--- a/frontend/src/features/Mission/components/MissionForm/constants.ts
+++ b/frontend/src/features/Mission/components/MissionForm/constants.ts
@@ -2,7 +2,7 @@
  * These properties does not require to be sync - so we do not update them.
  * @see https://github.com/MTES-MCT/monitorenv/blob/main/backend/src/main/kotlin/fr/gouv/cacem/monitorenv/infrastructure/api/adapters/publicapi/outputs/MissionDataOutput.kt#L11
  */
-export const MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES = [
+export const FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES = [
   'attachedReportingIds',
   'detachedReportingIds',
   'detachedReportings',
@@ -12,6 +12,18 @@ export const MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES = [
   'fishActions',
   'hasRapportNavActions',
   'observationsByUnit'
+]
+
+export const MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES = [
+  ...FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES,
+  'attachedReportings'
+]
+
+export const FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM = [
+  ...FULL_MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES,
+  'facade',
+  'updatedAtUtc',
+  'createdAtUtc'
 ]
 
 export const MISSION_EVENT_UNSYNCHRONIZED_PROPERTIES_IN_FORM = [

--- a/frontend/src/features/Mission/components/MissionForm/hooks/useListenMissionEventUpdates.ts
+++ b/frontend/src/features/Mission/components/MissionForm/hooks/useListenMissionEventUpdates.ts
@@ -5,14 +5,19 @@ import { useAppSelector } from '../../../../../hooks/useAppSelector'
 import { missionEventListener } from '../sse'
 
 const MISSION_UPDATES_URL = `/api/v1/missions/sse`
-const MISSION_UPDATE_EVENT = `MISSION_UPDATE`
-const FULL_MISSION_UPDATE_EVENT = `FULL_MISSION_UPDATE`
+export const MISSION_UPDATE_EVENT = `MISSION_UPDATE`
+export const FULL_MISSION_UPDATE_EVENT = `FULL_MISSION_UPDATE`
 
 export function useListenMissionEventUpdates() {
   const isListeningToEvents = useAppSelector(state => state.missionForms.isListeningToEvents)
   const eventSourceRef = useRef<EventSource>()
-  const { contextMissionEvent, setMissionEventInContext } = useMissionEventContext()
-  const listener = useRef(missionEventListener(mission => setMissionEventInContext(mission)))
+  const { contextMissionEvent, setEventType, setMissionEventInContext } = useMissionEventContext()
+  const listener = useRef(
+    missionEventListener((mission, event) => {
+      setMissionEventInContext(mission)
+      setEventType(event)
+    })
+  )
 
   useEffect(() => {
     eventSourceRef.current = new EventSource(MISSION_UPDATES_URL)
@@ -32,13 +37,18 @@ export function useListenMissionEventUpdates() {
       eventSourceRef.current?.removeEventListener(MISSION_UPDATE_EVENT, listener.current)
       eventSourceRef.current?.removeEventListener(FULL_MISSION_UPDATE_EVENT, listener.current)
       setMissionEventInContext(undefined)
+      setEventType(undefined)
 
       return
     }
-    listener.current = missionEventListener(mission => setMissionEventInContext(mission))
+    listener.current = missionEventListener((mission, event) => {
+      setMissionEventInContext(mission)
+      setEventType(event)
+    })
+
     eventSourceRef.current?.addEventListener(MISSION_UPDATE_EVENT, listener.current)
     eventSourceRef.current?.addEventListener(FULL_MISSION_UPDATE_EVENT, listener.current)
-  }, [isListeningToEvents, setMissionEventInContext])
+  }, [isListeningToEvents, setMissionEventInContext, setEventType])
 
   return contextMissionEvent
 }

--- a/frontend/src/features/Mission/components/MissionForm/sse.ts
+++ b/frontend/src/features/Mission/components/MissionForm/sse.ts
@@ -4,21 +4,21 @@ import { isMissionAutoUpdateEnabled } from './utils'
 
 import type { Mission } from '../../../../domain/entities/missions'
 
-export const missionEventListener = (callback: (mission: Mission) => void) => (event: MessageEvent) => {
-  const mission = undefine(JSON.parse(event.data)) as Mission
-
-  // eslint-disable-next-line no-console
-  console.log(`SSE: received a mission update.`)
-
-  if (!isMissionAutoUpdateEnabled()) {
+export const missionEventListener =
+  (callback: (mission: Mission, eventType: string) => void) => (event: MessageEvent) => {
+    const mission = undefine(JSON.parse(event.data)) as Mission
     // eslint-disable-next-line no-console
-    console.log(
-      'Skipping automatic update of mission form. ' +
-        "Set 'FRONTEND_MISSION_FORM_AUTO_UPDATE=true' feature flag to activate this feature."
-    )
+    console.log(`SSE: received a mission update.`)
 
-    return
+    if (!isMissionAutoUpdateEnabled()) {
+      // eslint-disable-next-line no-console
+      console.log(
+        'Skipping automatic update of mission form. ' +
+          "Set 'FRONTEND_MISSION_FORM_AUTO_UPDATE=true' feature flag to activate this feature."
+      )
+
+      return
+    }
+
+    callback(mission, event.type)
   }
-
-  callback(mission)
-}


### PR DESCRIPTION
L'event `MISSION_UPDATE` écoutait aussi les changements du champ `attachedReportings` donc comme on reçoit une `MissionEntity` la propriété était vide à chaque, supprimant ainsi les signalements.
Maintenant je vérifie les changements dans les champs suivant le type de l'événement

----

- [ ] Tests E2E (Cypress)
