### PR TITLE
[Mission] Résolution du bug sur le sélecteur de thèmes dans les surveillances

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@mtes-mct/monitor-ui": "24.29.2",
+        "@mtes-mct/monitor-ui": "24.30.0",
         "@react-pdf/renderer": "4.3.0",
         "@reduxjs/toolkit": "2.8.2",
         "@sentry/browser": "8.54.0",
@@ -3275,9 +3275,9 @@
       "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
     },
     "node_modules/@mtes-mct/monitor-ui": {
-      "version": "24.29.2",
-      "resolved": "https://registry.npmjs.org/@mtes-mct/monitor-ui/-/monitor-ui-24.29.2.tgz",
-      "integrity": "sha512-2MHMObotadg25tT/OJSogjYRLORjxTG4rQBPzIDTEoqkf4OGweuRHEBVe7sP3hg2lEHQDvALcyZ2g7YjN4Pc+A==",
+      "version": "24.30.0",
+      "resolved": "https://registry.npmjs.org/@mtes-mct/monitor-ui/-/monitor-ui-24.30.0.tgz",
+      "integrity": "sha512-Risib1q4NN7rIUYw4YtieqsKR3xhIZ9NNevPDhH1AkgUp6H09mDaJrq388i/gcD2QgrjsYdqpYAKJc8JzMB+ZQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/runtime": "7.27.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "test:unit:watch": "npm run test:unit -- --watch"
   },
   "dependencies": {
-    "@mtes-mct/monitor-ui": "24.29.2",
+    "@mtes-mct/monitor-ui": "24.30.0",
     "@react-pdf/renderer": "4.3.0",
     "@reduxjs/toolkit": "2.8.2",
     "@sentry/browser": "8.54.0",

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/ControlForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/ControlForm/index.tsx
@@ -1,3 +1,4 @@
+import { useGetThemesQuery } from '@api/themesAPI'
 import { actionFactory } from '@features/Mission/Missions.helpers'
 import { useAppDispatch } from '@hooks/useAppDispatch'
 import { useAppSelector } from '@hooks/useAppSelector'
@@ -79,6 +80,10 @@ export function ControlForm({
 
   const envActionIndex = envActions.findIndex(envAction => envAction.id === currentActionId)
   const currentAction = envActions?.[envActionIndex]
+
+  const startDate = currentAction?.actionStartDateTimeUtc ?? startDateTimeUtc ?? new Date().toISOString()
+  const { data } = useGetThemesQuery([startDate, startDate])
+  const themes = useMemo(() => Object.values(data ?? []), [data])
 
   const targetTypeOptions = getOptionsFromLabelledEnum(TargetTypeLabels)
 
@@ -184,10 +189,6 @@ export function ControlForm({
       setFieldValue(`envActions[${envActionIndex}].themes`, undefined)
     }
     setFieldValue(`envActions[${envActionIndex}].actionStartDateTimeUtc`, date)
-  }
-
-  const handleRemoveAction = () => {
-    removeControlAction()
   }
 
   const duplicateControl = useCallback(() => {
@@ -353,7 +354,7 @@ export function ControlForm({
           <StyledDeleteIconButton
             accent={Accent.SECONDARY}
             Icon={Icon.Delete}
-            onClick={handleRemoveAction}
+            onClick={removeControlAction}
             size={Size.SMALL}
             title="Supprimer le contrôle"
           />
@@ -388,7 +389,7 @@ export function ControlForm({
           )}
         </div>
 
-        <ActionThemes actionIndex={envActionIndex} actionType={ActionTypeEnum.CONTROL} />
+        <ActionThemes actionIndex={envActionIndex} actionType={ActionTypeEnum.CONTROL} themes={themes} />
         <ActionTags actionIndex={envActionIndex} />
 
         <div>

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/Tags/ActionTags.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/Tags/ActionTags.tsx
@@ -2,7 +2,7 @@ import { useGetTagsQuery } from '@api/tagsAPI'
 import { CheckTreePicker } from '@mtes-mct/monitor-ui'
 import { getTagsAsOptions, parseOptionsToTags } from '@utils/getTagsAsOptions'
 import { useField } from 'formik'
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import type { TagFromAPI } from 'domain/entities/tags'
@@ -11,14 +11,43 @@ type ActionTagsProps = {
   actionIndex: number
 }
 export function ActionTags({ actionIndex }: ActionTagsProps) {
+  const [searchQuery, setSearchQuery] = useState<string>('')
+  const ref = useRef<HTMLDivElement>(null)
+  const lastKeyPressed = useRef<string | null>(null)
+
   const [currentTags, , helpers] = useField<TagFromAPI[]>(`envActions[${actionIndex}].tags`)
 
   const { data } = useGetTagsQuery()
-
   const tagsOptions = useMemo(() => getTagsAsOptions(Object.values(data ?? [])), [data])
 
+  const forceFocus = useCallback(() => {
+    const input = ref.current?.querySelector('[role="searchbox"]') as HTMLInputElement
+    if (lastKeyPressed.current === 'Backspace' && searchQuery.length > 0) {
+      input.focus()
+    }
+  }, [searchQuery.length])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      lastKeyPressed.current = e.key
+    }
+    ref.current?.addEventListener('focusout', forceFocus)
+    ref.current?.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      ref.current?.removeEventListener('focusout', forceFocus)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      ref.current?.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [forceFocus])
+
+  const handleSearch = (nextQuery: string) => {
+    setSearchQuery(nextQuery)
+  }
+
   return (
-    <Wrapper data-cy="envaction-tags-element">
+    <Wrapper ref={ref} data-cy="envaction-tags-element">
       <CheckTreePicker
         childrenKey="subTags"
         isLight
@@ -28,6 +57,7 @@ export function ActionTags({ actionIndex }: ActionTagsProps) {
         onChange={option => {
           helpers.setValue(parseOptionsToTags(option) ?? [])
         }}
+        onSearch={handleSearch}
         options={tagsOptions}
         renderedChildrenValue="Sous-tags."
         renderedValue="Tags"

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/Themes/ActionThemes.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/Themes/ActionThemes.tsx
@@ -1,16 +1,10 @@
-import { useGetThemesQuery } from '@api/themesAPI'
 import { CheckTreePicker } from '@mtes-mct/monitor-ui'
 import { getThemesAsOptions, parseOptionsToThemes, sortThemes } from '@utils/getThemesAsOptions'
-import { useField, useFormikContext } from 'formik'
-import { useMemo } from 'react'
+import { useField } from 'formik'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import {
-  ActionTypeEnum,
-  type EnvActionControl,
-  type EnvActionSurveillance,
-  type Mission
-} from '../../../../../../domain/entities/missions'
+import { ActionTypeEnum } from '../../../../../../domain/entities/missions'
 
 import type { ThemeFromAPI } from 'domain/entities/themes'
 
@@ -19,39 +13,71 @@ export const GENERAL_SURVEILLANCE = 'Surveillance générale'
 type ActionThemeProps = {
   actionIndex: number
   actionType: ActionTypeEnum
+  themes: ThemeFromAPI[]
 }
-export function ActionThemes({ actionIndex, actionType }: ActionThemeProps) {
-  const {
-    setFieldValue,
-    values: { envActions, startDateTimeUtc }
-  } = useFormikContext<Mission<EnvActionSurveillance | EnvActionControl>>()
-  const [, error] = useField<ThemeFromAPI[]>(`envActions[${actionIndex}].themes`)
+export function ActionThemes({ actionIndex, actionType, themes }: ActionThemeProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [field, meta, helpers] = useField<ThemeFromAPI[]>(`envActions[${actionIndex}].themes`)
+  const [searchQuery, setSearchQuery] = useState<string>('')
 
-  const startDate = envActions[actionIndex]?.actionStartDateTimeUtc ?? (startDateTimeUtc || new Date().toISOString())
-
-  const { data } = useGetThemesQuery([startDate, startDate])
+  const lastKeyPressed = useRef<string | null>(null)
 
   const themesOptions = useMemo(() => {
     if (actionType === ActionTypeEnum.CONTROL) {
-      return getThemesAsOptions(Object.values(data ?? []))
+      return getThemesAsOptions(themes)
         .filter(theme => theme.name !== GENERAL_SURVEILLANCE)
         .sort(sortThemes)
     }
 
-    return getThemesAsOptions(Object.values(data ?? []))
-  }, [actionType, data])
+    return getThemesAsOptions(themes)
+  }, [actionType, themes])
 
-  const label =
-    envActions[actionIndex]?.actionType === ActionTypeEnum.CONTROL
-      ? 'Thématiques et sous-thématiques de contrôle'
-      : 'Thématiques et sous-thématiques de surveillance'
+  const forceFocus = useCallback(() => {
+    const input = ref.current?.querySelector('[role="searchbox"]') as HTMLInputElement
+    if (lastKeyPressed.current === 'Backspace' && searchQuery.length > 0) {
+      input.focus()
+    }
+  }, [searchQuery.length])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      lastKeyPressed.current = e.key
+    }
+    ref.current?.addEventListener('focusout', forceFocus)
+    ref.current?.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      ref.current?.removeEventListener('focusout', forceFocus)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      ref.current?.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [forceFocus])
+
+  const label = useMemo(
+    () =>
+      actionType === ActionTypeEnum.CONTROL
+        ? 'Thématiques et sous-thématiques de contrôle'
+        : 'Thématiques et sous-thématiques de surveillance',
+    [actionType]
+  )
+
+  const handleChange = useCallback(
+    (option: any) => {
+      helpers.setValue(parseOptionsToThemes(option) ?? [])
+    },
+    [helpers]
+  )
+
+  const handleSearch = (nextQuery: string) => {
+    setSearchQuery(nextQuery)
+  }
 
   return (
-    <ActionThemeWrapper data-cy="envaction-theme-element">
+    <ActionThemeWrapper ref={ref} data-cy="envaction-theme-element">
       <CheckTreePicker
-        key={themesOptions.length}
         childrenKey="subThemes"
-        error={error.error}
+        error={meta.error}
         isErrorMessageHidden
         isLight
         isMultiSelect={actionType === ActionTypeEnum.SURVEILLANCE}
@@ -59,11 +85,10 @@ export function ActionThemes({ actionIndex, actionType }: ActionThemeProps) {
         label={label}
         labelKey="name"
         name={`envActions[${actionIndex}].themes`}
-        onChange={option => {
-          setFieldValue(`envActions[${actionIndex}].themes`, parseOptionsToThemes(option))
-        }}
+        onChange={handleChange}
+        onSearch={handleSearch}
         options={themesOptions}
-        value={envActions[actionIndex]?.themes}
+        value={field.value}
         valueKey="id"
       />
     </ActionThemeWrapper>

--- a/frontend/src/features/Mission/components/MissionForm/MissionForm.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/MissionForm.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mtes-mct/monitor-ui'
 import { useMissionEventContext } from 'context/mission/useMissionEventContext'
 import { useFormikContext } from 'formik'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { generatePath } from 'react-router'
 import styled from 'styled-components'
 import { useDebouncedCallback } from 'use-debounce'
@@ -124,9 +124,12 @@ export function MissionForm({
     }
   }, [attachedReportingIds, values?.attachedReportingIds?.length, setFieldValue, attachedReportings])
 
-  const handleSetCurrentActionId = (actionId: string | undefined) => {
-    dispatch(missionFormsActions.setActiveActionId(actionId))
-  }
+  const handleSetCurrentActionId = useCallback(
+    (actionId: string | undefined) => {
+      dispatch(missionFormsActions.setActiveActionId(actionId))
+    },
+    [dispatch]
+  )
 
   const returnToEdition = () => {
     dispatch(sideWindowActions.setShowConfirmCancelModal(false))

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -14,13 +14,11 @@ import { isMissionNew } from '../../utils'
 import type { Mission as MissionType, NewMission } from '../../../../domain/entities/missions'
 
 export function MissionFormWrapper() {
-  const activeMissionId = useAppSelector(state => state.missionForms.activeMissionId)
-
   const selectedMission = useAppSelector(state => getActiveMission(state.missionForms))
+  const activeMissionId = selectedMission?.missionForm?.id
+  const engagedControlUnit = useMemo(() => selectedMission?.engagedControlUnit, [selectedMission])
 
-  const engagedControlUnit = selectedMission?.engagedControlUnit
-
-  const activeAction = selectedMission?.activeAction
+  const activeAction = useMemo(() => selectedMission?.activeAction, [selectedMission])
 
   const missionIsNewMission = useMemo(() => isMissionNew(activeMissionId), [activeMissionId])
 
@@ -61,7 +59,7 @@ export function MissionFormWrapper() {
       )}
 
       <Formik
-        key={missionValues.id}
+        key={activeMissionId}
         enableReinitialize
         initialValues={missionValues}
         onSubmit={noop}


### PR DESCRIPTION
- Seul moyen de contournement trouvé: utiliser les event de keydown et focus pour forcer le focus sur l'input du composant
- J'ai mis la ref sur le wrapper et non sur le composant en lui-même car il a déjà une ref côté monitor-ui
- Le souci vient d'une part de la side-window et d 'autres part de l'enregistrement auto qui engendre beaucoup de re-render, plus formik qui fait aussi de re-render tout seul dans son coin

Il reste un souci que je n'arrive pas à régler quand on sélectionne des options, une requête PUT est envoyée (voire plusieurs si on sélectionne plusieurs options) , le temps de recevoir la réponse et de mettre à jour le formulaire on reperd le focus (voir vidéo)

## Related Pull Requests & Issues

- Resolve #2488 


----

- [ ] Tests E2E (Cypress)
