### PR TITLE
[Brief] Afficher les liens legicem des zones reg liées à une ZDV en dessous de l'image si plus de deux liens

### DIFF
--- a/frontend/src/features/Dashboard/components/DashboardForm/Amps/Layer.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardForm/Amps/Layer.tsx
@@ -8,11 +8,10 @@ import { Accent, Icon, IconButton, OPENLAYERS_PROJECTION, THEME, WSG84_PROJECTIO
 import { setFitToExtent } from 'domain/shared_slices/Map'
 import { Projection, transformExtent } from 'ol/proj'
 import { createRef } from 'react'
-import styled from 'styled-components'
 
 import { MonitorEnvLayers } from '../../../../../domain/entities/layers/constants'
 import { useAppDispatch } from '../../../../../hooks/useAppDispatch'
-import { StyledLayer } from '../style'
+import { LayerName, LayerNameContainer, StyledLayer } from '../style'
 
 type AmpLayerProps = {
   isPinned?: boolean
@@ -70,15 +69,15 @@ export function Layer({ isPinned = false, isSelected, layerId }: AmpLayerProps) 
       $metadataIsShown={openPanel?.id === layerId && openPanel?.isPinned === isSelected}
       onClick={toggleZoneMetadata}
     >
-      <Wrapper>
+      <LayerNameContainer>
         <LayerLegend layerType={MonitorEnvLayers.AMP} legendKey={layer?.name} type={layer?.type} />
-        <LayerSelector.Name
+        <LayerName
           data-cy={`dashboard-${isSelected ? 'selected-' : ''}amp-zone-${layer?.id}`}
           title={layer?.type ?? 'aucun'}
         >
           {layer?.type ?? 'AUCUN TYPE'}
-        </LayerSelector.Name>
-      </Wrapper>
+        </LayerName>
+      </LayerNameContainer>
       <LayerSelector.IconGroup>
         {isSelected ? (
           <IconButton
@@ -102,8 +101,3 @@ export function Layer({ isPinned = false, isSelected, layerId }: AmpLayerProps) 
     </StyledLayer>
   )
 }
-
-const Wrapper = styled.div`
-  display: flex;
-  align-items: center;
-`

--- a/frontend/src/features/Dashboard/components/DashboardForm/RegulatoryAreas/Layer.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardForm/RegulatoryAreas/Layer.tsx
@@ -8,13 +8,12 @@ import { displayTags } from '@utils/getTagsAsOptions'
 import { transformExtent } from 'ol/proj'
 import Projection from 'ol/proj/Projection'
 import { createRef } from 'react'
-import styled from 'styled-components'
 
 import { useGetRegulatoryLayersQuery } from '../../../../../api/regulatoryLayersAPI'
 import { MonitorEnvLayers } from '../../../../../domain/entities/layers/constants'
 import { setFitToExtent } from '../../../../../domain/shared_slices/Map'
 import { useAppDispatch } from '../../../../../hooks/useAppDispatch'
-import { StyledLayer } from '../style'
+import { LayerName, LayerNameContainer, StyledLayer } from '../style'
 
 type RegulatoryLayerProps = {
   isPinned?: boolean
@@ -82,20 +81,19 @@ export function Layer({ isPinned = false, isSelected, layerId }: RegulatoryLayer
       $metadataIsShown={openPanel?.id === layerId && openPanel?.isPinned === isSelected}
       onClick={toggleZoneMetadata}
     >
-      <Wrapper>
+      <LayerNameContainer>
         <LayerLegend
           layerType={MonitorEnvLayers.REGULATORY_ENV}
           legendKey={layer?.entityName ?? 'aucun'}
           type={displayTags(layer?.tags) ?? 'aucun'}
         />
-        <LayerSelector.Name
-          $withLargeWidth
+        <LayerName
           data-cy={`dashboard-${isSelected ? 'selected-' : ''}regulatory-area-zone-${layer?.id}`}
           title={layer?.entityName}
         >
           {layer?.entityName ?? 'AUCUN NOM'}
-        </LayerSelector.Name>
-      </Wrapper>
+        </LayerName>
+      </LayerNameContainer>
       <LayerSelector.IconGroup>
         {isSelected ? (
           <IconButton
@@ -119,8 +117,3 @@ export function Layer({ isPinned = false, isSelected, layerId }: RegulatoryLayer
     </StyledLayer>
   )
 }
-
-const Wrapper = styled.div`
-  display: flex;
-  align-items: center;
-`

--- a/frontend/src/features/Dashboard/components/DashboardForm/VigilanceAreas/Layer.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardForm/VigilanceAreas/Layer.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components'
 import { MonitorEnvLayers } from '../../../../../domain/entities/layers/constants'
 import { setFitToExtent } from '../../../../../domain/shared_slices/Map'
 import { useAppDispatch } from '../../../../../hooks/useAppDispatch'
+import { LayerName, LayerNameContainer } from '../style'
 
 type VigilanceAreaLayerProps = {
   isPinned?: boolean
@@ -66,20 +67,20 @@ export function Layer({ isPinned = false, isSelected = false, vigilanceArea }: V
       $withBorderBottom
       onClick={toggleZoneMetadata}
     >
-      <NameContainer>
+      <LayerNameContainer>
         <LayerLegend
           isDisabled={vigilanceArea?.isArchived}
           layerType={MonitorEnvLayers.VIGILANCE_AREA}
           legendKey={vigilanceArea?.comments ?? 'aucun nom'}
           type={vigilanceArea?.name ?? 'aucun nom'}
         />
-        <LayerSelector.Name
+        <LayerName
           data-cy={`dashboard-${isSelected ? 'selected-' : ''}vigilance-area-zone-${vigilanceArea?.name}`}
           title={vigilanceArea?.name}
         >
           {vigilanceArea?.name}
-        </LayerSelector.Name>
-      </NameContainer>
+        </LayerName>
+      </LayerNameContainer>
       <TagAndButtons data-cy={`dashboard-vigilance-area-zone-tags-and-buttons-${vigilanceArea.id}`}>
         {vigilanceArea.visibility === VigilanceArea.Visibility.PRIVATE && (
           <StyledTag accent={Accent.PRIMARY} title="Zone de vigilance interne au CACEM">
@@ -127,10 +128,7 @@ const StyledLayer = styled(LayerSelector.Layer)<{ $isSelected: boolean; $metadat
     border-top: 1px solid ${p => p.theme.color.lightGray};
   }
 `
-const NameContainer = styled.div`
-  align-items: center;
-  display: flex;
-`
+
 const TagAndButtons = styled.div`
   display: flex;
   gap: 10px;

--- a/frontend/src/features/Dashboard/components/DashboardForm/style.ts
+++ b/frontend/src/features/Dashboard/components/DashboardForm/style.ts
@@ -34,3 +34,18 @@ export const StyledLayer = styled(LayerSelector.Layer)<{ $isSelected: boolean; $
        
     `}
 `
+
+export const LayerNameContainer = styled.div`
+  align-items: center;
+  display: flex;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+export const LayerName = styled.span`
+  margin-left: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`

--- a/frontend/src/features/Dashboard/components/Pdf/VigilanceAreas/index.tsx
+++ b/frontend/src/features/Dashboard/components/Pdf/VigilanceAreas/index.tsx
@@ -8,6 +8,7 @@ import { customDayjs, THEME } from '@mtes-mct/monitor-ui'
 import { Image, Link, Text, View } from '@react-pdf/renderer'
 import { displayTags } from '@utils/getTagsAsOptions'
 
+import { ArrowRight } from '../icons/ArrowRight'
 import { ExternalLink } from '../icons/ExternalLink'
 import { AreaImage } from '../Layout/AreaImage'
 import { areaStyle, layoutStyle } from '../style'
@@ -159,38 +160,34 @@ export function VigilanceAreas({
                       </View>
                     </View>
                   </View>
-                  {regulatoryAreas.length > 0 && (
+                  {regulatoryAreas.length > 0 && regulatoryAreas.length < 3 && (
                     <View style={[areaStyle.content, { borderTop: `1 solid ${THEME.color.gainsboro}` }]}>
-                      <View>
-                        <Text style={[areaStyle.description, { width: 'auto' }]}>Réglementations en lien</Text>
-                        {regulatoryAreas.map((linkedRegulatoryArea, index) => (
-                          <View
-                            key={linkedRegulatoryArea.id}
-                            style={{ marginBottom: index === regulatoryAreas.length - 1 ? 0 : 7 }}
-                          >
-                            <Link href={linkedRegulatoryArea.url} style={layoutStyle.link}>
-                              <View style={[layoutStyle.row, { alignItems: 'center', marginBottom: 3, width: 'auto' }]}>
-                                <Text>Résumé réglementaire sur Légicem </Text>
-                                <ExternalLink color={layoutStyle.link.color} size={8} />
-                              </View>
-                            </Link>
-                            <Text style={[areaStyle.details, { fontSize: 6.2 }]}>{linkedRegulatoryArea.refReg}</Text>
-                          </View>
-                        ))}
-                      </View>
+                      <Text style={[areaStyle.description, { width: 'auto' }]}>Réglementations en lien</Text>
+                      {regulatoryAreas.map((linkedRegulatoryArea, index) => (
+                        <View
+                          key={linkedRegulatoryArea.id}
+                          style={{ marginBottom: index === regulatoryAreas.length - 1 ? 0 : 7 }}
+                        >
+                          <Link href={linkedRegulatoryArea.url} style={layoutStyle.link}>
+                            <View style={[layoutStyle.row, { alignItems: 'center', marginBottom: 3, width: 'auto' }]}>
+                              <Text>Résumé réglementaire sur Légicem </Text>
+                              <ExternalLink color={layoutStyle.link.color} size={8} />
+                            </View>
+                          </Link>
+                          <Text style={[areaStyle.details, { fontSize: 6.2 }]}>{linkedRegulatoryArea.refReg}</Text>
+                        </View>
+                      ))}
                     </View>
                   )}
                   {amps.length > 0 && (
                     <View style={[areaStyle.content, { borderTop: `1 solid ${THEME.color.gainsboro}` }]}>
-                      <View>
-                        <Text style={[areaStyle.description, { width: 'auto' }]}>AMP en lien</Text>
-                        {amps.map(linkedAmp => (
-                          <View key={linkedAmp.id} style={[areaStyle.details, { width: 'auto' }]}>
-                            <Text style={{ fontWeight: 'bold' }}>{linkedAmp.name} /</Text>
-                            <Text>{linkedAmp.type}</Text>
-                          </View>
-                        ))}
-                      </View>
+                      <Text style={[areaStyle.description, { width: 'auto' }]}>AMP en lien</Text>
+                      {amps.map(linkedAmp => (
+                        <View key={linkedAmp.id} style={[areaStyle.details, { width: 'auto' }]}>
+                          <Text style={{ fontWeight: 'bold' }}>{linkedAmp.name} /</Text>
+                          <Text>{linkedAmp.type}</Text>
+                        </View>
+                      ))}
                     </View>
                   )}
                   {vigilanceArea.links && vigilanceArea.links?.length > 0 && (
@@ -210,6 +207,34 @@ export function VigilanceAreas({
                   )}
                 </View>
               </View>
+              {regulatoryAreas.length > 0 && regulatoryAreas.length > 2 && (
+                <View
+                  style={[
+                    areaStyle.content,
+                    {
+                      border: `1 solid ${THEME.color.gainsboro}`,
+                      borderBottom: vigilanceArea.comments ? 'none' : `1 solid ${THEME.color.gainsboro}`,
+                      fontSize: 6.8
+                    }
+                  ]}
+                  wrap
+                >
+                  <Text style={[areaStyle.description, { width: 'auto' }]}>Résumés réglementaires sur Légicem</Text>
+
+                  {regulatoryAreas.map(linkedRegulatoryArea => (
+                    <View
+                      key={linkedRegulatoryArea.id}
+                      style={[layoutStyle.row, { alignItems: 'center', marginBottom: 3, width: 'auto' }]}
+                    >
+                      <ArrowRight color={THEME.color.slateGray} size={10} />
+                      <Link href={linkedRegulatoryArea.url}>
+                        <Text style={[layoutStyle.link, { fontSize: 6.2 }]}>{linkedRegulatoryArea.refReg}</Text>
+                      </Link>
+                    </View>
+                  ))}
+                </View>
+              )}
+
               <View style={[areaStyle.content, { border: `1 solid ${THEME.color.gainsboro}`, fontSize: 6.8 }]} wrap>
                 <View>
                   <Text style={[areaStyle.description, { width: 'auto' }]}>Commentaires</Text>

--- a/frontend/src/features/Dashboard/components/Pdf/icons/ArrowRight.tsx
+++ b/frontend/src/features/Dashboard/components/Pdf/icons/ArrowRight.tsx
@@ -1,0 +1,18 @@
+import { G, Line, Path, Rect, Svg } from '@react-pdf/renderer'
+
+type IconProps = {
+  color: string
+  size: number
+}
+export function ArrowRight({ color, size }: IconProps) {
+  return (
+    <Svg height={size} viewBox="0 0 20 20" width={size}>
+      <Rect fill="none" height={size} width={size} />
+
+      <G>
+        <Path d="M7.5,4.5 L13,10 L7.5,15.5" fill="none" stroke={color} strokeWidth={2} />
+        <Line stroke={color} strokeWidth={2} x1={2} x2={13} y1={10} y2={10} />
+      </G>
+    </Svg>
+  )
+}

--- a/frontend/src/features/layersSelector/utils/LayerSelector.style.ts
+++ b/frontend/src/features/layersSelector/utils/LayerSelector.style.ts
@@ -26,14 +26,14 @@ const Layer = styled.span<{ $metadataIsShown?: boolean; $withBorderBottom?: bool
   }
 `
 
-const Name = styled.span<{ $withLargeWidth?: boolean }>`
+const Name = styled.span`
   display: block;
   margin-left: 8px;
   overflow: hidden;
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: ${p => (p.$withLargeWidth ? '463px' : '280px')};
+  width: 280px;
 `
 
 const ZonesNumber = styled.span`


### PR DESCRIPTION
Cela permet d'éviter un dépassement de l'encadré qui vient mordre sur le commentaire ou des photos

## Related Pull Requests & Issues

- Resolve #2497

<img width="782" height="579" alt="Capture d’écran 2025-09-12 à 09 58 55" src="https://github.com/user-attachments/assets/6b7d3fa2-5ca2-46c6-a6e7-aac501580ad6" />
<img width="762" height="763" alt="Capture d’écran 2025-09-12 à 09 58 48" src="https://github.com/user-attachments/assets/e7de8ccd-49d4-4522-834b-69936de22395" />

----

- [ ] Tests E2E (Cypress)
