### PR TITLE
[Carte] Résolution du bug lorsqu'on créé un point depuis la carte

### DIFF
--- a/frontend/src/features/map/draw/DrawModal.tsx
+++ b/frontend/src/features/map/draw/DrawModal.tsx
@@ -183,6 +183,10 @@ export function DrawModal() {
       }
 
       isEditingInInputRef.current = true
+      if (!mustZoomToFeature) {
+        return
+      }
+
       setInputCoordinates(nextCoordinates)
       if (!nextCoordinates) {
         return
@@ -201,7 +205,7 @@ export function DrawModal() {
 
       dispatch(addFeatureToDrawedFeature(nextFeature))
       const extent = nextFeature.getGeometry()?.getExtent()
-      if (extent && mustZoomToFeature) {
+      if (extent) {
         dispatch(setFitToExtent(extent))
       }
     },


### PR DESCRIPTION
Il y a eu une régression suite à mes changements ici (https://github.com/MTES-MCT/monitorenv/pull/2971/changes#diff-929e874adb92121072b259e41f200fbcac6deb3f35b697d425978fd607559fdc) 
Quand on cliquait sur la carte on recalculait les coordonnées, du coup le point bougeait légéremrent quand on était très zoomé. Il gardait cependant les mêmes coordonnées

Je fais maintenant un return pour éviter ce recalcul

## Related Pull Requests & Issues

- Resolve #3009
----

- [ ] Tests E2E (Cypress)
