### PR TITLE
[Data] Résolution du bug sur les flows des zones réglementaires

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.229__re_add_regulatory_areas_group.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.229__re_add_regulatory_areas_group.sql
@@ -1,0 +1,36 @@
+DELETE FROM regulatory_areas_group;
+DELETE FROM regulatory_areas WHERE area_type = 'GROUP';
+
+WITH original_areas AS MATERIALIZED (SELECT id, layer_name, geom
+                                     FROM regulatory_areas),
+     grouped_reg AS (SELECT layer_name,
+                            ST_Multi(
+                                    ST_CollectionExtract(
+                                            ST_Collect(ST_CollectionExtract(geom, 3)),
+                                            3
+                                    )
+                            ) AS geom
+                     FROM regulatory_areas
+                     GROUP BY layer_name),
+     base_id AS (SELECT GREATEST(COALESCE(MAX(id), 0), 999999) AS base_id
+                 FROM regulatory_areas),
+     new_groups AS (
+         INSERT INTO regulatory_areas (id, area_type, layer_name, geom, creation)
+             SELECT ids.id,
+                    'GROUP',
+                    ids.layer_name,
+                    ids.geom,
+                    now()
+             FROM (SELECT base_id + ROW_NUMBER() OVER (ORDER BY gr.layer_name) AS id,
+                          gr.layer_name,
+                          gr.geom
+                   FROM grouped_reg gr
+                            CROSS JOIN base_id) ids
+             RETURNING id, layer_name)
+INSERT
+INTO regulatory_areas_group (regulatory_area_id, group_id)
+SELECT o.id,
+       g.id
+FROM original_areas o
+         JOIN new_groups g
+              ON g.layer_name = o.layer_name;

--- a/backend/src/main/resources/db/migration/internal/V0.229__re_add_regulatory_areas_group.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.229__re_add_regulatory_areas_group.sql
@@ -1,9 +1,10 @@
 DELETE FROM regulatory_areas_group;
 DELETE FROM regulatory_areas WHERE area_type = 'GROUP';
 
-WITH original_areas AS MATERIALIZED (SELECT id, layer_name, geom
-                                     FROM regulatory_areas),
+WITH original_areas AS MATERIALIZED (SELECT id, layer_name, location, geom
+                                          FROM regulatory_areas),
      grouped_reg AS (SELECT layer_name,
+                                location,
                             ST_Multi(
                                     ST_CollectionExtract(
                                             ST_Collect(ST_CollectionExtract(geom, 3)),
@@ -11,26 +12,29 @@ WITH original_areas AS MATERIALIZED (SELECT id, layer_name, geom
                                     )
                             ) AS geom
                      FROM regulatory_areas
-                     GROUP BY layer_name),
+                        GROUP BY layer_name, location),
      base_id AS (SELECT GREATEST(COALESCE(MAX(id), 0), 999999) AS base_id
                  FROM regulatory_areas),
      new_groups AS (
-         INSERT INTO regulatory_areas (id, area_type, layer_name, geom, creation)
+          INSERT INTO regulatory_areas (id, area_type, layer_name, location, geom, creation)
              SELECT ids.id,
                     'GROUP',
                     ids.layer_name,
+                      ids.location,
                     ids.geom,
                     now()
              FROM (SELECT base_id + ROW_NUMBER() OVER (ORDER BY gr.layer_name) AS id,
                           gr.layer_name,
+                             gr.location,
                           gr.geom
                    FROM grouped_reg gr
                             CROSS JOIN base_id) ids
-             RETURNING id, layer_name)
+              RETURNING id, layer_name, location)
 INSERT
 INTO regulatory_areas_group (regulatory_area_id, group_id)
 SELECT o.id,
        g.id
 FROM original_areas o
          JOIN new_groups g
-              ON g.layer_name = o.layer_name;
+                ON g.layer_name = o.layer_name
+                    AND g.location IS NOT DISTINCT FROM o.location;

--- a/pipeline/src/flows/update_cacem_regulatory_areas.py
+++ b/pipeline/src/flows/update_cacem_regulatory_areas.py
@@ -15,7 +15,7 @@ from src.shared_tasks.update_queries import (
     update_required,
 )
 
-from src.generic_tasks import extract
+from src.generic_tasks import extract, load
 
 @task
 def extract_cacem_regulatory_areas_hashes() -> pd.DataFrame:
@@ -41,6 +41,15 @@ def extract_monitorenv_regulatory_areas_hashes() -> pd.DataFrame:
     return extract(
         db_name="monitorenv_remote",
         query_filepath="monitorenv/regulatory_areas_hashes_for_cacem.sql",
+    )
+
+
+@task
+def extract_monitorenv_regulatory_areas_groups() -> pd.DataFrame:
+    """Extract regulatory areas groups from monitorenv for CACEM upsert."""
+    return extract(
+        db_name="monitorenv_remote",
+        query_filepath="monitorenv/regulatory_areas_groups_for_cacem.sql",
     )
 
 @task
@@ -89,6 +98,8 @@ def update_cacem_regulatory_areas(new_regulatory_areas: pd.DataFrame):
                     authorization_periods   character varying,
                     prohibition_periods     character varying,
                     additional_ref_reg      jsonb,
+                    location                character varying,
+                    area_type               character varying,
                     themes                  character varying,
                     tags                    character varying
                 )
@@ -112,6 +123,8 @@ def update_cacem_regulatory_areas(new_regulatory_areas: pd.DataFrame):
            "authorization_periods",
            "prohibition_periods",
            "additional_ref_reg",
+           "location",
+           "area_type",
            "themes",
            "tags",
         ]
@@ -146,6 +159,8 @@ def update_cacem_regulatory_areas(new_regulatory_areas: pd.DataFrame):
                 authorization_periods = tmp.authorization_periods,
                 prohibition_periods = tmp.prohibition_periods,
                 additional_ref_reg = tmp.additional_ref_reg,
+                location = tmp.location,
+                area_type = tmp.area_type,
                 themes = tmp.themes,
                 tags = tmp.tags
                 FROM tmp_regulatory_areas tmp
@@ -153,6 +168,21 @@ def update_cacem_regulatory_areas(new_regulatory_areas: pd.DataFrame):
                 """
             )
         )
+
+
+@task
+def load_new_regulatory_areas_groups(new_regulatory_areas_groups: pd.DataFrame):
+    """Upsert monitorenv regulatory areas groups into CACEM."""
+    load(
+        new_regulatory_areas_groups,
+        table_name="reg_cacem",
+        schema="prod",
+        db_name="cacem_local",
+        logger=get_run_logger(),
+        how="upsert",
+        table_id_column="id",
+        df_id_column="id",
+    )
 
 
 
@@ -164,17 +194,20 @@ def update_cacem_regulatory_areas_flow(
     if is_integration:
         logger.info("Running in integration mode - no update will be performed")
         return
-    
 
     cacem_hashes = extract_cacem_regulatory_areas_hashes()
     monitor_env_hashes = extract_monitorenv_regulatory_areas_hashes()
-
     inner_merged = merge_hashes(cacem_hashes, monitor_env_hashes, "inner")
 
+    new_regulatory_areas_groups = extract_monitorenv_regulatory_areas_groups()
+    load_new_regulatory_areas_groups(new_regulatory_areas_groups)
+    
     ids_to_update = select_ids_to_update(inner_merged)
     logger.info(f"Ids to update: {ids_to_update}")
     cond_update = update_required(ids_to_update)
     if cond_update is True:
         new_regulatory_areas = extract_env_regulatory_areas(ids_to_update)
         update_cacem_regulatory_areas(new_regulatory_areas)
+
+
 

--- a/pipeline/src/queries/cross/cacem/regulatory_areas.sql
+++ b/pipeline/src/queries/cross/cacem/regulatory_areas.sql
@@ -21,6 +21,7 @@ SELECT
   prohibition_periods,
   additional_ref_reg,
   location,
+  area_type,
   md5(
     COALESCE(st_multi(ST_SimplifyPreserveTopology(ST_CurveToLine(geom), 0.00001))::text, '') ||
     COALESCE(ref_reg::text, '')

--- a/pipeline/src/queries/cross/cacem/regulatory_areas_hashes_for_env.sql
+++ b/pipeline/src/queries/cross/cacem/regulatory_areas_hashes_for_env.sql
@@ -5,4 +5,5 @@ FROM
   prod.reg_cacem
 WHERE
   geom IS NOT NULL
-  AND ref_reg IS NOT NULL;
+  AND ref_reg IS NOT NULL
+  AND area_type = 'ZONE';

--- a/pipeline/src/queries/monitorenv/regulatory_areas.sql
+++ b/pipeline/src/queries/monitorenv/regulatory_areas.sql
@@ -14,10 +14,11 @@ SELECT
     ra.plan,
     ra.authorization_periods,
     ra.prohibition_periods,
+    ra.location,
+    ra.area_type,
     ra.additional_ref_reg,
     STRING_AGG(DISTINCT t.name, ',' ORDER BY t.name) AS themes,
-    STRING_AGG(DISTINCT tag.name, ',' ORDER BY tag.name) AS tags,
-    ra.location
+    STRING_AGG(DISTINCT tag.name, ',' ORDER BY tag.name) AS tags
 FROM regulatory_areas ra
 LEFT JOIN themes_regulatory_areas tra
        ON tra.regulatory_areas_id = ra.id

--- a/pipeline/src/queries/monitorenv/regulatory_areas_groups_for_cacem.sql
+++ b/pipeline/src/queries/monitorenv/regulatory_areas_groups_for_cacem.sql
@@ -1,0 +1,22 @@
+SELECT
+    ra.id,
+    st_multi(ST_SimplifyPreserveTopology(ST_CurveToLine(ra.geom), 0.00001)) geom,
+    ra.url,
+    ra.layer_name,
+    ra.facade,
+    ra.creation,
+    ra.edition_bo,
+    ra.edition_cacem,
+    ra.date,
+    ra.date_fin,
+    ra.type,
+    ra.resume,
+    ra.poly_name,
+    ra.plan,
+    ra.authorization_periods,
+    ra.prohibition_periods,
+    ra.location,
+    ra.area_type,
+    ra.additional_ref_reg
+FROM regulatory_areas ra
+WHERE area_type = 'GROUP';

--- a/pipeline/src/queries/monitorenv/regulatory_areas_hashes_for_cacem.sql
+++ b/pipeline/src/queries/monitorenv/regulatory_areas_hashes_for_cacem.sql
@@ -30,5 +30,6 @@ LEFT JOIN tags_regulatory_areas trt
        ON trt.regulatory_areas_id = ra.id
 LEFT JOIN tags tag
        ON tag.id = trt.tags_id
+WHERE ra.area_type = 'ZONE'
 GROUP BY ra.id;
 

--- a/pipeline/src/queries/monitorenv/regulatory_areas_hashes_for_cacem.sql
+++ b/pipeline/src/queries/monitorenv/regulatory_areas_hashes_for_cacem.sql
@@ -15,11 +15,11 @@ SELECT
         COALESCE(ra.resume::text, '') ||
         COALESCE(ra.authorization_periods::text, '') ||
         COALESCE(ra.prohibition_periods::text, '') ||
+        COALESCE(ra.location::text, '') ||
+        COALESCE(ra.area_type::text, '') ||
         COALESCE(ra.additional_ref_reg::text, '') ||
         COALESCE(STRING_AGG(DISTINCT t.name, ',' ORDER BY t.name)::text, '') ||
-        COALESCE(STRING_AGG(DISTINCT tag.name, ',' ORDER BY tag.name)::text, '') ||
-        COALESCE(ra.location::text, '') ||
-        COALESCE(ra.area_type::text, '')
+        COALESCE(STRING_AGG(DISTINCT tag.name, ',' ORDER BY tag.name)::text, '')
   ) AS monitorenv_row_hash
 FROM public.regulatory_areas ra
 LEFT JOIN themes_regulatory_areas tra
@@ -30,6 +30,5 @@ LEFT JOIN tags_regulatory_areas trt
        ON trt.regulatory_areas_id = ra.id
 LEFT JOIN tags tag
        ON tag.id = trt.tags_id
-WHERE area_type = 'ZONE'
 GROUP BY ra.id;
 

--- a/pipeline/src/queries/monitorenv/regulatory_areas_hashes_for_env.sql
+++ b/pipeline/src/queries/monitorenv/regulatory_areas_hashes_for_env.sql
@@ -1,4 +1,5 @@
 SELECT
     id,
     row_hash AS monitorenv_row_hash
-FROM public.regulatory_areas;
+FROM public.regulatory_areas
+WHERE area_type = 'ZONE';

--- a/pipeline/tests/test_data/cacem_database/V666.507__regulatory_areas.sql
+++ b/pipeline/tests/test_data/cacem_database/V666.507__regulatory_areas.sql
@@ -54,7 +54,8 @@ INSERT INTO prod.reg_cacem (
     additional_ref_reg,
     themes,
     tags,
-    location
+    location,
+    area_type
 ) VALUES (
     1,
     'MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))',
@@ -78,7 +79,8 @@ INSERT INTO prod.reg_cacem (
     '[{"id": "55a403ba-3077-40aa-8241-967be5314b8c", "refReg": "Arrêté interpréfectoral du 22 décembre..."}]',
     'AMP sans réglementation particulière,Pêche à pied',
     'tag1,tag2',
-    'location1'
+    'location1',
+    'ZONE'
 );
 
 /* NEW REGULATORY AREAS */

--- a/pipeline/tests/test_data/remote_database/V666.34__Reset_test_regulatory_areas.sql
+++ b/pipeline/tests/test_data/remote_database/V666.34__Reset_test_regulatory_areas.sql
@@ -28,6 +28,8 @@ INSERT INTO
     plan,
     authorization_periods,
     prohibition_periods,
+    location,
+    area_type,
     additional_ref_reg,
     row_hash
   )
@@ -56,6 +58,8 @@ VALUES
     'plan1',
     'période d''autorisation1',
     'période de prohibition1',
+    'location1',
+    'ZONE',
     '[{"id": "55a403ba-3077-40aa-8241-967be5314b8c", "refReg": "Arrêté interpréfectoral du 22 décembre..."}]',
     md5(COALESCE(st_multi (ST_SimplifyPreserveTopology (ST_CurveToLine ('MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))'::geometry), 0.00001))::text, '') || COALESCE('ref_reg1'::text, ''))
   );
@@ -81,6 +85,8 @@ INSERT INTO
     plan,
     authorization_periods,
     prohibition_periods,
+    location,
+    area_type,
     additional_ref_reg,
     row_hash
   )
@@ -109,6 +115,8 @@ VALUES
     'plan2',
     'période d''autorisation2',
     'période de prohibition2',
+    'location2',
+    'ZONE',
     null,
     md5(COALESCE(st_multi (ST_SimplifyPreserveTopology (ST_CurveToLine ('MULTIPOLYGON(((120 -20,135 -20,135 -10,120 -10,120 -20)))'::geometry), 0.00001))::text, '') || COALESCE('ref_reg2'::text, ''))
   );

--- a/pipeline/tests/test_flows/test_update_cacem_regulatory_areas.py
+++ b/pipeline/tests/test_flows/test_update_cacem_regulatory_areas.py
@@ -2,8 +2,8 @@ import pandas as pd
 
 from src.db_config import create_engine
 from src.read_query import read_query
-from src.generic_tasks import load
 from src.flows.update_cacem_regulatory_areas import (
+    load_new_regulatory_areas_groups,
     update_cacem_regulatory_areas,
     update_cacem_regulatory_areas_flow
 )
@@ -17,6 +17,27 @@ def test_update_cacem_regulatory_areas_flow(
     state = update_cacem_regulatory_areas_flow(return_state=True)
 
     assert state.is_completed()
+
+
+def test_load_new_regulatory_areas_groups_uses_upsert_on_id(monkeypatch):
+    captured = {}
+
+    def fake_load(df, **kwargs):
+        captured["df"] = df
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr("src.flows.update_cacem_regulatory_areas.load", fake_load)
+
+    new_regulatory_areas_groups = pd.DataFrame({"id": [1]})
+
+    load_new_regulatory_areas_groups(new_regulatory_areas_groups)
+
+    assert captured["kwargs"]["how"] == "upsert"
+    assert captured["kwargs"]["table_id_column"] == "id"
+    assert captured["kwargs"]["df_id_column"] == "id"
+    assert captured["kwargs"]["table_name"] == "reg_cacem"
+    assert captured["kwargs"]["schema"] == "prod"
+    assert captured["kwargs"]["db_name"] == "cacem_local"
 
 
 
@@ -50,6 +71,8 @@ def test_update_cacem_regulatory_areas_replace_tags(reset_test_data):
             "authorization_periods": [None],
             "prohibition_periods": [None],
             "additional_ref_reg": [None],
+            "location": [None],
+            "area_type": [None],
             "themes": [None],
             "tags": ["D,E"],
         }

--- a/pipeline/tests/test_flows/test_update_env_regulatory_areas.py
+++ b/pipeline/tests/test_flows/test_update_env_regulatory_areas.py
@@ -1,9 +1,9 @@
 import pandas as pd
 
-from src.generic_tasks import load
 from src.flows.update_env_regulatory_areas import (
     update_env_regulatory_areas_flow
 )
+
 
 def test_update_env_regulatory_areas_flow(
     reset_test_data,


### PR DESCRIPTION
Aujourd'hui en plus des zones reg, la table regulatory_areas comprend les groupe de zone. Ce sont des zones reg avec les mêmes données, l'ajout de la colonne `area_type` permet de définir si c'est une 'ZONE' ou un 'GROUP'

Suite à ces changements y a un souci dans le flow de mise à jour des zones reg côté env et cacem: 
- pour la mise à jour QGIS du cacem -> on ne récupérait pas les nouvelles colonnes `location` et `area_type` + on filtrait sur les zones reg avec `area_type= 'ZONE' ` or on veut aussi envoyer les groupes dans QGIS
- pour la mise à jour des zones reg côté env -> comme les groupes sont créés côtés env, les ids n'existent pas encore dans QGIS, donc le flow les supprimaient. J'ai ajouté une étape pour mettre à jour les  zones reg de type 'GROUP' avant des mettre à jour les zones reg de type 'ZONE'.



- J'ai du refaire une migration pour créer les groupes car les flows de mise à jour des zones reg (cacem -> env) en ont supprimé certains.
- J'ai ajouté les nouveaux champs dans le flow qui met à jour la base cacem + mise à jour des groupe de zones reg dans la base cacem
----

- [ ] Tests E2E (Cypress)
